### PR TITLE
Enhance AFNI HRF specs for new pipeline

### DIFF
--- a/R/hrf-afni.R
+++ b/R/hrf-afni.R
@@ -18,11 +18,12 @@ NULL
 #'
 #' @export
 #' @rdname AFNI_HRF-class
-AFNI_HRF <- function(name, nbasis, params) {
-  structure(name, 
-            nbasis=as.integer(nbasis), 
-            params=params, 
-            class=c("AFNI_HRF"))
+AFNI_HRF <- function(name, nbasis, params, span = 24) {
+  structure(name,
+            nbasis = as.integer(nbasis),
+            params = params,
+            span = span,
+            class = c("AFNI_HRF", "HRF"))
   
 }
 
@@ -39,12 +40,12 @@ as.character.AFNI_HRF <- function(x,...) {
 #' @param stop the stop time for sin/poly/csplin models
 #' @export
 #' @return an \code{afni_hrfspec} instance
-afni_hrf <- function(..., basis=c("spmg1", "block", "dmblock",           
-                                  "tent",   "csplin", "poly",  "sin",        
-                                  "gam", "spmg2", "spmg3", "wav"), 
-                                  onsets=NULL, durations=NULL, prefix=NULL, subset=NULL, 
-                                  nbasis=1, contrasts=NULL, id=NULL, 
-                                  lag=0,
+afni_hrf <- function(..., basis=c("spmg1", "block", "dmblock",
+                                  "tent",   "csplin", "poly",  "sin",
+                                  "gam", "spmg2", "spmg3", "wav"),
+                                  onsets=NULL, durations=NULL, prefix=NULL, subset=NULL,
+                                  nbasis=1, contrasts=NULL, id=NULL,
+                                  lag=0, precision = 0.3, summate = TRUE,
                                   start=NULL, stop=NULL) {
   
   ## TODO cryptic error message when argument is mispelled and is then added to ...
@@ -109,6 +110,8 @@ afni_hrf <- function(..., basis=c("spmg1", "block", "dmblock",
     prefix=prefix,
     subset=rlang::enexpr(subset), # Capture subset expression
     lag=lag,
+    precision = precision,
+    summate = summate,
     contrasts=cset)
   
   class(ret) <- c("afni_hrfspec", "hrfspec", "list")
@@ -131,9 +134,10 @@ afni_hrf <- function(..., basis=c("spmg1", "block", "dmblock",
 #' 
 #' @export
 #' @return an \code{afni_trialwise_hrfspec} instance
-afni_trialwise <- function(label, basis=c("spmg1", "block", "dmblock", "gamma", "wav"), 
-                     onsets=NULL, durations=0, subset=NULL, 
-                      id=NULL, start=0, stop=22) {
+afni_trialwise <- function(label, basis=c("spmg1", "block", "dmblock", "gamma", "wav"),
+                     onsets=NULL, durations=0, subset=NULL,
+                      id=NULL, start=0, stop=22,
+                      precision = 0.3, summate = TRUE) {
   
   ## TODO cryptic error message when argument is mispelled and is then added to ...
   basis <- match.arg(basis)
@@ -157,7 +161,9 @@ afni_trialwise <- function(label, basis=c("spmg1", "block", "dmblock", "gamma", 
     hrf=hrf,
     onsets=onsets,
     durations=durations,
-    subset=rlang::enexpr(subset))
+    subset=rlang::enexpr(subset),
+    precision = precision,
+    summate = summate)
   
   class(ret) <- c("afni_trialwise_hrfspec", "hrfspec", "list")
   ret
@@ -179,6 +185,9 @@ construct.afni_hrfspec <- function(x, model_spec, ...) {
     evterm=et,
     sampling_frame=model_spec$sampling_frame,
     hrfspec=x,
+    precision = x$precision,
+    summate = x$summate,
+    lag = x$lag,
     contrasts=x$contrasts,
     id=if(!is.null(x$id)) x$id else et$varname
   )
@@ -218,6 +227,8 @@ construct.afni_trialwise_hrfspec <- function(x, model_spec, ...) {
     evterm=et,
     sampling_frame=model_spec$sampling_frame,
     hrfspec=x,
+    precision = x$precision,
+    summate = x$summate,
     id=x$id
   )
   

--- a/tests/testthat/test_afni_hrf.R
+++ b/tests/testthat/test_afni_hrf.R
@@ -114,3 +114,48 @@ test_that("can construct an an afni model with trialwise regressor and a Polynom
   expect_equal(2, length(baseline_terms(fmod)))
   expect_null(contrast_weights(fmod)$repnum)
 })
+
+test_that("afni_hrf accepts precision, summate, and lag", {
+
+  facedes$repnum <- factor(facedes$rep_num)
+  scans <- paste0("rscan0", 1:6, ".nii")
+  dset <- fmri_dataset(scans=scans,
+                       mask="mask.nii",
+                       TR=1.5,
+                       run_length=rep(436,6),
+                       event_table=facedes)
+
+  dset <- .assign_dummy_mask_to_dataset(dset)
+
+  espec <- event_model(onset ~ afni_hrf(repnum, basis="spmg1", precision=0.2, summate=FALSE, lag=2),
+                       data=facedes,
+                       block=~run,
+                       sampling_frame=dset$sampling_frame)
+
+  term <- terms(espec)[[1]]
+  expect_equal(term$hrfspec$precision, 0.2)
+  expect_false(term$hrfspec$summate)
+  expect_equal(term$hrfspec$lag, 2)
+})
+
+test_that("afni_trialwise accepts precision and summate", {
+
+  scans <- paste0("rscan0", 1:6, ".nii")
+  dset <- fmri_dataset(scans=scans,
+                       mask="mask.nii",
+                       TR=1.5,
+                       run_length=rep(436,6),
+                       event_table=facedes)
+
+  dset <- .assign_dummy_mask_to_dataset(dset)
+
+  espec <- event_model(onset ~ afni_trialwise("trial", precision=0.2, summate=FALSE),
+                       data=facedes,
+                       block=~run,
+                       sampling_frame=dset$sampling_frame)
+
+  term <- terms(espec)[[1]]
+  expect_equal(term$hrfspec$precision, 0.2)
+  expect_false(term$hrfspec$summate)
+})
+


### PR DESCRIPTION
## Summary
- extend AFNI HRF constructors to store `precision`, `summate` and optional `lag`
- ensure AFNI HRF objects inherit from `HRF`
- propagate these fields when constructing afni terms
- test AFNI constructors with the new parameters

## Testing
- `R CMD check` *(fails: R not installed)*