### PR TITLE
Fix block-level row indices for global constant baseline

### DIFF
--- a/R/baseline_model.R
+++ b/R/baseline_model.R
@@ -323,9 +323,9 @@ construct.baselinespec <- function(x, model_spec, ...) {
     mat <- matrix(1, nrow = sum(bl), ncol = 1)
     cnames <- paste0("base_", x$basis)
     colnames(mat) <- cnames
-    # colind and rowind are simple for a single global column
+    # column index is a single value, but rows are tracked per block
     colind <- list(1)
-    rowind <- list(1:nrow(mat))
+    rowind <- split(seq_len(nrow(mat)), blockids(sampling_frame))
     return(baseline_term(x$name, mat, colind, rowind))
   }
   

--- a/tests/testthat/test_baseline.R
+++ b/tests/testthat/test_baseline.R
@@ -67,7 +67,7 @@ test_that("can construct a baseline_model with basis='constant'", {
   sframe <- sampling_frame(blocklens=c(100,100), TR=2)
   # Intercept option should be ignored/overridden when basis is constant
   bmodel_runwise <- baseline_model(basis="constant", sframe=sframe, intercept="runwise")
-  bmodel_global <- baseline_model(basis="constant", sframe=sframe, intercept="global")
+  bmodel <- baseline_model(basis="constant", sframe=sframe, intercept="global")
   bmodel_none <- baseline_model(basis="constant", sframe=sframe, intercept="none")
   
   # Expect only 1 column (the constant baseline itself) regardless of intercept 
@@ -93,9 +93,15 @@ test_that("can construct a baseline_model with basis='constant'", {
   expect_equal(names(terms(bmodel_runwise)), c("drift"))
   
   # basis='constant', intercept='global' -> drift term = single column of 1s. Total = 1 col.
-  expect_equal(ncol(design_matrix(bmodel_global)), 1)
-  expect_equal(length(terms(bmodel_global)), 1)
-  expect_equal(names(terms(bmodel_global)), c("drift"))
+  expect_equal(ncol(design_matrix(bmodel)), 1)
+  expect_equal(length(terms(bmodel)), 1)
+  expect_equal(names(terms(bmodel)), c("drift"))
+
+  # Using blockid should subset rows by block
+  expect_equal(
+    nrow(design_matrix(bmodel, blockid = 2)),
+    blocklens(sframe)[2]
+  )
   
   # basis='constant', intercept='none' -> treated like 'runwise' by construct.baselinespec? No, intercept is passed.
   # construct.baselinespec doesn't explicitly use intercept='none' for constant basis differently than 'runwise'.


### PR DESCRIPTION
## Summary
- fix row index calculation for constant baseline with global intercept
- verify row counts when requesting a specific block

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*