### PR TITLE
Document baseline intercept handling

### DIFF
--- a/R/baseline_model.R
+++ b/R/baseline_model.R
@@ -111,7 +111,8 @@ make_nuisance_term <- function(nuisance_list,
 #' @param degree Integer; degree of the spline/polynomial function.
 #' @param sframe A sampling_frame object.
 #' @param intercept Character; whether to include an intercept ("runwise", "global", or "none").
-#'   (Automatically set to FALSE when basis == "constant".)
+#'   Ignored when \code{basis == "constant"} because the drift term already
+#'   provides the constant baseline.
 #' @param nuisance_list Optional list of nuisance matrices (one matrix per fMRI block).
 #'
 #' @return An object of class "baseline_model".

--- a/man/baseline_model.Rd
+++ b/man/baseline_model.Rd
@@ -20,7 +20,7 @@ baseline_model(
 \item{sframe}{A sampling_frame object.}
 
 \item{intercept}{Character; whether to include an intercept ("runwise", "global", or "none").
-(Automatically set to FALSE when basis == "constant".)}
+Ignored when \code{basis == "constant"} because the drift term already provides the constant baseline.}
 
 \item{nuisance_list}{Optional list of nuisance matrices (one matrix per fMRI block).}
 }


### PR DESCRIPTION
## Summary
- clarify that `intercept` is ignored when `basis == "constant"` in `baseline_model`
- rebuild corresponding documentation

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`