### PR TITLE
Handle zero variance in Standardized

### DIFF
--- a/man/Standardized.Rd
+++ b/man/Standardized.Rd
@@ -13,5 +13,6 @@ Standardized(x)
 an instance of class \code{Standardized} extending \code{ParametricBasis}
 }
 \description{
-Standardize a numeric vector by centering and scaling, handling NAs appropriately
+Standardize a numeric vector by centering and scaling, handling NAs appropriately.\cr
+\strong{Note}: If the computed standard deviation is \code{NA} or zero, a small constant (\code{1e-6}) is used. The returned matrix has one column named after the standardized variable.
 }

--- a/tests/testthat/test_standardized.R
+++ b/tests/testthat/test_standardized.R
@@ -1,0 +1,14 @@
+test_that("Standardized assigns column name", {
+  x <- c(1, 2, 3)
+  b <- Standardized(x)
+  expect_equal(colnames(b$y), b$name)
+  p <- predict(b, c(4, 5))
+  expect_equal(colnames(p), b$name)
+})
+
+test_that("Standardized handles zero variance", {
+  x <- rep(1, 5)
+  b <- Standardized(x)
+  expect_equal(b$sd, 1e-6)
+  expect_equal(as.numeric(b$y[,1]), rep(0, 5))
+})


### PR DESCRIPTION
## Summary
- protect against zero or NA variance in `Standardized`
- keep column name on matrices created by `Standardized` and `predict.Standardized`
- update documentation for the new behaviour
- add unit tests for `Standardized`

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test_standardized.R')"` *(fails: command not found)*