### PR TITLE
Fix BSpline constructor degree handling

### DIFF
--- a/R/basis.R
+++ b/R/basis.R
@@ -172,7 +172,7 @@ columns.Standardized <- function(x) {
 BSpline <- function(x, degree) {
   mc <- match.call()
   argname <- as.character(mc[["x"]])[1]
-  pres <- bs(x,degree)
+  pres <- bs(x, degree = degree)
   n <- paste0("bs_", argname)
   ret <- list(x=x, y=pres, fun="bs", argname=argname, 
               name=n,

--- a/tests/testthat/test_event_vector.R
+++ b/tests/testthat/test_event_vector.R
@@ -130,8 +130,17 @@ test_that("event_basis wrapper works and creates correct event object", {
   expect_equal(levels(eb), expected_cols, ignore_attr = TRUE) 
   
   expect_s3_class(eb$meta$basis, "ParametricBasis")
-  #expect_equal(eb$meta$basis, basis, ignore_attr = TRUE) 
+  #expect_equal(eb$meta$basis, basis, ignore_attr = TRUE)
   expect_null(eb$meta$levels)
+})
+
+test_that("BSpline constructor respects degree argument", {
+  skip_if_not_installed("splines")
+  x <- seq(0, 1, length.out = 10)
+  deg <- 4
+  b <- BSpline(x, degree = deg)
+  expect_equal(ncol(b$y), deg)
+  expect_equal(nbasis(b), deg)
 })
 
 # ==================================


### PR DESCRIPTION
## Summary
- fix BSpline() to pass `degree=` to splines::bs
- test BSpline degree behavior

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`