### PR TITLE
Fix F-test p-value return

### DIFF
--- a/R/con_stats.R
+++ b/R/con_stats.R
@@ -49,7 +49,7 @@ fit_Ftests <- function(object) {
     f <- ms/(ssr[i]/dfr)
     
     P <- pf(f, df, dfr, lower.tail = FALSE)
-    list(F=f, P=p)
+    list(F = f, P = P)
   })
   
   FMat <- do.call(rbind, lapply(ret, "[[", "F"))


### PR DESCRIPTION
## Summary
- fix return value for F-test helper in con_stats

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*