### PR TITLE
Add subset parameter for covariate

### DIFF
--- a/R/covariate.R
+++ b/R/covariate.R
@@ -41,6 +41,7 @@ parse_term <- function(vars, ttype) {
 #' @param data A data.frame containing the variables.
 #' @param id An optional identifier for the covariate term.
 #' @param prefix An optional prefix to add to the covariate names.
+#' @param subset Optional expression used to subset the covariate data.
 #'
 #' @return A list containing information about the covariate term with class 
 #' 'covariatespec' that can be used within an event_model.
@@ -72,7 +73,7 @@ parse_term <- function(vars, ttype) {
 #' * [hrf()] for creating HRF-convolved event terms
 #'
 #' @export
-covariate <- function(..., data, id=NULL, prefix=NULL) {
+covariate <- function(..., data, id=NULL, prefix=NULL, subset=NULL) {
   vars <- as.list(substitute(list(...)))[-1] 
   parsed <- parse_term(vars, "covariate")
   term <- parsed$term
@@ -97,7 +98,7 @@ covariate <- function(..., data, id=NULL, prefix=NULL) {
     varnames=varnames, ## list of all variables (e.g. list(x,y))
     vars=term, ## list of unparsed vars
     label=label, ## "covariate(x)" the full expression
-    subset=substitute(subset))
+    subset=rlang::enexpr(subset))
   
   class(ret) <- c("covariatespec", "hrfspec", "list")
   ret

--- a/man/covariate.Rd
+++ b/man/covariate.Rd
@@ -4,7 +4,7 @@
 \alias{covariate}
 \title{Construct a Covariate Term}
 \usage{
-covariate(..., data, id = NULL, prefix = NULL)
+covariate(..., data, id = NULL, prefix = NULL, subset = NULL)
 }
 \arguments{
 \item{...}{A variable argument set of covariate names.}
@@ -14,6 +14,7 @@ covariate(..., data, id = NULL, prefix = NULL)
 \item{id}{An optional identifier for the covariate term.}
 
 \item{prefix}{An optional prefix to add to the covariate names.}
+\item{subset}{Optional expression used to subset the covariate data.}
 }
 \value{
 A list containing information about the covariate term with class

--- a/tests/testthat/test_regressor.R
+++ b/tests/testthat/test_regressor.R
@@ -189,6 +189,12 @@ test_that("can construct a model with a raw covariate term", {
   expect_true(!is.null(fmod))
 })
 
+test_that("covariate captures subset expression", {
+  df <- data.frame(x = 1:4, y = 5:8, flag = c(TRUE, FALSE, TRUE, FALSE))
+  cspec <- covariate(x, y, data = df, subset = flag)
+  expect_true(identical(cspec$subset, rlang::expr(flag)))
+})
+
 test_that("facedes model with rep_num", {
   facedes$repnum <- factor(facedes$rep_num)
   sframe <- sampling_frame(blocklens=rep(436/2,max(facedes$run)), TR=2)


### PR DESCRIPTION
## Summary
- support `subset` argument for `covariate()` and store expression via `rlang::enexpr`
- document new parameter in Rd
- test capturing of subset expression

## Testing
- `devtools::test()` *(fails: R not installed)*