### PR TITLE
Refactor parse_term

### DIFF
--- a/R/covariate.R
+++ b/R/covariate.R
@@ -1,17 +1,16 @@
 #' @keywords internal
 #' @noRd
 parse_term <- function(vars, ttype) {
-  dim <- length(vars) # number of variables
-  term <- deparse(vars[[1]],backtick=TRUE) # first covariate
-  if (dim>1) # then deal with further covariates
-    for (i in 2:dim) term[i]<-deparse(vars[[i]],backtick=TRUE)
-  for (i in 1:dim) term[i] <- attr(terms(reformulate(term[i])),"term.labels")
-  
-  full.call<-paste(ttype, "(",term[1],sep="")
-  if (dim > 1) for (i in 2:dim) full.call<-paste(full.call,",",term[i],sep="")
-  label <- paste(full.call,")",sep="")   # label for parameters of this term  
-  
-  list(term=term, label=label)
+  nvars <- length(vars) # number of variables
+
+  term <- vapply(vars, function(v) {
+    parsed <- deparse(v, backtick = TRUE)
+    attr(terms(reformulate(parsed)), "term.labels")
+  }, character(1))
+
+  label <- sprintf("%s(%s)", ttype, paste(term, collapse = ","))
+
+  list(term = term, label = label)
 }
 
 #' Construct a Covariate Term

--- a/tests/testthat/test_parse_term.R
+++ b/tests/testthat/test_parse_term.R
@@ -1,0 +1,9 @@
+library(fmrireg)
+
+test_that("parse_term handles multiple variables and complex expressions", {
+  vars <- list(quote(x), quote(log(y + 1)), quote(Poly(rt, 3)))
+  res <- fmrireg:::parse_term(vars, "covariate")
+  expect_equal(res$term, c("x", "log(y + 1)", "Poly(rt, 3)"))
+  expect_equal(res$label, "covariate(x,log(y + 1),Poly(rt, 3))")
+})
+


### PR DESCRIPTION
## Summary
- rename internal `dim` variable to `nvars`
- use `vapply` to construct `term` and `label`
- add regression test for `parse_term`

## Testing
- `R CMD build .` *(fails: R not installed)*
- `R -e 'testthat::test_dir("tests/testthat")'` *(fails: R not installed)*