### PR TITLE
Validate covariate row count

### DIFF
--- a/R/covariate.R
+++ b/R/covariate.R
@@ -119,15 +119,24 @@ construct.covariatespec <- function(x, model_spec, sampling_frame=NULL, ...) {
   }))
   
   colnames(mat) <- x$varnames
-  
+
   cterm <- covariate_term(x$name, mat)
-  
+
   sframe <- if (is.null(sampling_frame)) {
     model_spec$sampling_frame
   } else {
     sampling_frame
   }
-  
+
+  ## Validate that the covariate matrix matches the sampling frame length
+  expected_rows <- sum(sframe$blocklens)
+  if (nrow(mat) != expected_rows) {
+    stop(sprintf(
+      "Covariate term '%s' has %d rows but sampling_frame expects %d",
+      x$name, nrow(mat), expected_rows
+    ), call. = FALSE)
+  }
+
   ret <- list(
     varname=x$name,
     spec=x,

--- a/tests/testthat/test_covariate_length.R
+++ b/tests/testthat/test_covariate_length.R
@@ -1,0 +1,13 @@
+test_that("covariate data length must match sampling frame", {
+  sframe <- sampling_frame(blocklens = c(50, 50), TR = 1)
+
+  # create covariate data that is too short
+  bad_dat <- data.frame(x = rnorm(75), y = rnorm(75))
+
+  expect_error(
+    event_model(onset ~ covariate(x, y, data = bad_dat),
+                data = data.frame(onset = seq_len(100), run = rep(1:2, each = 50)),
+                block = ~ run, sampling_frame = sframe),
+    "sampling_frame expects"
+  )
+})


### PR DESCRIPTION
## Summary
- check that covariate matrix rows match sampling frame
- throw error for mismatched lengths
- test covariate length validation

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*