### PR TITLE
Fix trailing whitespace at EOF

### DIFF
--- a/R/evaluate-helpers.R
+++ b/R/evaluate-helpers.R
@@ -258,4 +258,4 @@ eval_loop <- function(p, ...) {
     }
   }
   result
-} 
+}


### PR DESCRIPTION
## Summary
- remove trailing space at end of `R/evaluate-helpers.R`
- ensure file ends with newline

## Testing
- `git status --short`