### PR TITLE
Sanitize column names for event_matrix

### DIFF
--- a/R/event-classes.R
+++ b/R/event-classes.R
@@ -152,6 +152,10 @@ event <- function(value, name, onsets, blockids, durations = 0, subset = NULL) {
 #' @param durations Numeric vector of event durations (seconds), or a scalar.
 #' @param subset Optional logical vector indicating which events to keep.
 #'
+#' If `mat` has column names and more than one column, those names are
+#' sanitized using `.sanitizeName()` before being stored. The sanitized
+#' column names are returned by `levels()` for the resulting event object.
+#'
 #' @return An S3 object of class `event` and `event_seq`.
 #'
 #' @examples
@@ -228,6 +232,10 @@ event_variable <- function(vec, name, onsets, blockids = 1, durations = 0, subse
 #' @param durations Numeric vector of event durations (seconds), or a scalar.
 #' @param subset Optional logical vector indicating which events to keep.
 #'
+#' If `mat` has column names and more than one column, those names are
+#' sanitized using `.sanitizeName()` before being stored. The sanitized
+#' column names are returned by `levels()` for the resulting event object.
+#'
 #' @return An S3 object of class `event` and `event_seq`.
 #'
 #' @examples
@@ -247,6 +255,10 @@ event_matrix <- function(mat, name, onsets, blockids = 1, durations = 0, subset 
   assert_that(nrow(mat) == length(onsets),
               msg = sprintf("Length mismatch for '%s': nrow(mat)=%d, length(onsets)=%d",
                           name, nrow(mat), length(onsets)))
+  # Sanitize column names when multiple columns are provided
+  if (ncol(mat) > 1 && !is.null(colnames(mat))) {
+      colnames(mat) <- .sanitizeName(colnames(mat))
+  }
   
   # Call the unified internal constructor
   event(value = mat, 

--- a/man/event_matrix.Rd
+++ b/man/event_matrix.Rd
@@ -19,6 +19,11 @@ event_matrix(mat, name, onsets, blockids = 1, durations = 0, subset = NULL)
 
 \item{subset}{Optional logical vector indicating which events to keep.}
 }
+\details{
+When \code{mat} has more than one column and column names are provided,
+they are sanitized using \code{.sanitizeName()}. The sanitized names are
+returned by \code{levels()} on the resulting event object.
+}
 \value{
 An S3 object of class \code{event} and \code{event_seq}.
 }

--- a/tests/testthat/test_event_vector.R
+++ b/tests/testthat/test_event_vector.R
@@ -100,6 +100,14 @@ test_that("event_matrix wrapper works and creates correct event object", {
   expect_null(em$meta)
 })
 
+test_that("event_matrix sanitizes colnames when necessary", {
+  mat <- matrix(rnorm(4), ncol = 2)
+  colnames(mat) <- c("A B", "C-D")
+  onsets <- c(1, 2)
+  ev <- event_matrix(mat, "mat", onsets, rep(1, 2))
+  expect_equal(levels(ev), .sanitizeName(c("A B", "C-D")), ignore_attr = TRUE)
+})
+
 # Add test for event_basis wrapper
 test_that("event_basis wrapper works and creates correct event object", {
   skip_if_not_installed("splines")


### PR DESCRIPTION
## Summary
- sanitize colnames in `event_matrix` when matrix has multiple columns
- note sanitized names in `event_matrix` documentation
- add regression test verifying sanitization behavior

## Testing
- `R CMD check --no-manual` *(fails: `R` command not found)*