### PR TITLE
Fix hrfspec list handling in formula parser

### DIFF
--- a/R/event_model_helpers.R
+++ b/R/event_model_helpers.R
@@ -34,8 +34,10 @@ find_and_eval_hrf_calls <- function(expr, data, f_env) {
     }
     
     # Recursive case: Traverse arguments of other calls (like + or *)
-    # Use lapply for clarity instead of explicit loop + c()
-    results <- unlist(lapply(rlang::call_args(expr), find_and_eval_hrf_calls, data, f_env), recursive = FALSE)
+    # Collect results from each argument and concatenate while preserving
+    # list structure (so each hrfspec remains intact)
+    results_list <- lapply(rlang::call_args(expr), find_and_eval_hrf_calls, data, f_env)
+    results <- do.call(c, results_list)
     return(results)
     
   } else {

--- a/tests/testthat/test_parse_event_formula.R
+++ b/tests/testthat/test_parse_event_formula.R
@@ -1,0 +1,21 @@
+library(testthat)
+
+# Ensure we use testthat edition 3
+local_edition(3)
+
+# Test that parse_event_formula returns hrfspec list intact
+
+test_that("parse_event_formula returns hrfspec objects for multiple hrf calls", {
+  events <- data.frame(
+    onset = 1:4,
+    condition = factor(c("a", "b", "a", "b")),
+    modulator = rnorm(4)
+  )
+
+  form <- onset ~ hrf(condition) + hrf(modulator)
+
+  parsed <- fmrireg:::parse_event_formula(form, events)
+
+  expect_equal(nrow(parsed$spec_tbl), 2)
+  expect_true(all(vapply(parsed$spec_tbl$spec, inherits, logical(1), "hrfspec")))
+})


### PR DESCRIPTION
## Summary
- keep hrfspec objects intact when parsing formula terms
- add a regression test for `parse_event_formula`

## Testing
- `Rscript -e '1+1'` *(fails: command not found)*