### PR TITLE
Implement DSL-110

### DIFF
--- a/R/fmridsl.R
+++ b/R/fmridsl.R
@@ -176,6 +176,9 @@ parse_and_validate_config <- function(yaml_file) {
       onset_column = "onset",
       duration_column = "duration",
       block_column = "run"
+    ),
+    hrfs = list(
+      canonical = list(type = "SPMCanonical")
     )
   )
 

--- a/tests/testthat/test-parse-and-validate-config.R
+++ b/tests/testthat/test-parse-and-validate-config.R
@@ -81,6 +81,22 @@ test_that("hrfs block validates entries", {
   expect_equal(res$hrfs$custom$type, "GammaFunction")
 })
 
+test_that("missing hrfs block uses canonical default", {
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = "./data"),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(),
+    terms = list(),
+    models = list()
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf))
+
+  res <- AD(tf)
+  expect_equal(res$hrfs$canonical$type, "SPMCanonical")
+})
+
 test_that("invalid hrfs entry fails", {
   tf <- tempfile(fileext = ".yml")
   cfg <- list(


### PR DESCRIPTION
## Summary
- add canonical HRF defaults in `parse_and_validate_config`
- test default HRF behavior when no `hrfs` block is given

## Testing
- `devtools::test()` *(fails: R not installed)*