### PR TITLE
Implement DSL-201 BIDS loading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,8 +64,9 @@ Suggests:
     shiny,
     mgcv,
     ggforce,
-    roxyglobals (>= 0.2.1)
-Remotes: 
+    roxyglobals (>= 0.2.1),
+    bidser
+Remotes:
     bbuchsbaum/neuroim2,
     bbuchsbaum/multivarious,
     bbuchsbaum/fmristore,

--- a/R/fmridsl.R
+++ b/R/fmridsl.R
@@ -643,6 +643,7 @@ parse_and_validate_config <- function(yaml_file) {
 
   errors$stop_if_invalid("Configuration validation failed")
 
+  attr(config_list, "validated_schema") <- TRUE
   config_list
 }
 

--- a/R/fmridsl_builder.R
+++ b/R/fmridsl_builder.R
@@ -1,0 +1,51 @@
+#' Build fmri_config Object from Validated IOR List (Contextual Validation)
+#'
+#' This function performs context-dependent checks and constructs
+#' an \code{fmri_config} object. DSL-201 covers loading the BIDS
+#' project specified in the configuration and verifying that the
+#' dataset path exists.
+#'
+#' @param validated_ior A list produced by [parse_and_validate_config()].
+#' @return An object of class \code{fmri_config}.
+#' @keywords internal
+build_config_from_ior <- function(validated_ior) {
+  if (!isTRUE(attr(validated_ior, "validated_schema"))) {
+    stop("Input 'validated_ior' must come from parse_and_validate_config().")
+  }
+
+  errors <- ValidationErrors$new()
+
+  bids_path <- fs::path_expand(validated_ior$dataset$path)
+
+  if (!fs::dir_exists(bids_path)) {
+    errors$add_error("dataset$path", paste0("BIDS directory does not exist: '", bids_path, "'"))
+    errors$stop_if_invalid("Cannot proceed without a valid BIDS project")
+  }
+
+  project <- NULL
+  tryCatch({
+    project <- bidser::bids_project(bids_path)
+  }, error = function(e) {
+    errors$add_error("dataset$path", paste0("Failed to load BIDS project at '", bids_path, "': ", e$message))
+  })
+
+  errors$stop_if_invalid("Cannot proceed without a valid BIDS project")
+
+  config <- list(spec = validated_ior, project = project, validated = TRUE)
+  class(config) <- "fmri_config"
+  config
+}
+
+#' Load, Validate, and Build fMRI Analysis Configuration
+#'
+#' This is the main user-facing helper for the DSL. It parses the YAML
+#' file, applies defaults, validates against the schema, then calls
+#' [build_config_from_ior()] to perform BIDS checks.
+#'
+#' @param yaml_file Path to the YAML configuration file.
+#' @return An \code{fmri_config} object.
+#' @export
+load_fmri_config <- function(yaml_file) {
+  validated_ior <- parse_and_validate_config(yaml_file)
+  build_config_from_ior(validated_ior)
+}

--- a/tests/testthat/test-build-config-from-ior.R
+++ b/tests/testthat/test-build-config-from-ior.R
@@ -1,0 +1,21 @@
+library(testthat)
+AD <- fmrireg:::parse_and_validate_config
+BC <- fmrireg:::build_config_from_ior
+LF <- fmrireg::load_fmri_config
+
+write_yaml <- function(lst, path) yaml::write_yaml(lst, path)
+
+test_that("nonexistent dataset path fails", {
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = "./nonexistent"),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(),
+    terms = list(),
+    models = list()
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf))
+
+  expect_error(LF(tf), "BIDS directory does not exist")
+})


### PR DESCRIPTION
## Summary
- add BIDS project loading helper `build_config_from_ior`
- expose `load_fmri_config` for convenient YAML parsing and building
- mark validated config objects
- list `bidser` in Suggests
- test BIDS path existence check

## Testing
- `R -e "testthat::test_file('tests/testthat/test-build-config-from-ior.R')"` *(fails: `bash: R: command not found`)*