### PR TITLE
Implement DSL-205

### DIFF
--- a/tests/testthat/test-dsl-205.R
+++ b/tests/testthat/test-dsl-205.R
@@ -1,0 +1,101 @@
+library(testthat)
+
+skip_if_not_installed("bidser")
+
+LF <- fmrireg::load_fmri_config
+
+create_temp_bids205 <- function() {
+  participants_df <- tibble::tibble(participant_id = "01", age = 30)
+  file_structure_df <- tibble::tribble(
+    ~subid, ~session, ~datatype, ~task, ~run, ~suffix,                    ~fmriprep,
+    "01",   NA,       "func",    "taskA", "01", "bold",                   FALSE,
+    "01",   NA,       "func",    "taskA", "01", "events",                 FALSE,
+    "01",   NA,       "func",    "taskA", "01", "desc-confounds_timeseries", TRUE
+  )
+
+  ev_file <- bidser:::generate_bids_filename(subid="01", task="taskA", run="01", suffix="events.tsv")
+  ev_path <- file.path("sub-01", "func", ev_file)
+  event_data <- list()
+  event_data[[ev_path]] <- tibble::tibble(
+    onset = c(1, 3),
+    duration = c(1, 1),
+    cond = c("a", "b"),
+    run = c(1, 1)
+  )
+
+  conf_file <- bidser:::generate_bids_filename(subid="01", task="taskA", run="01", suffix="desc-confounds_timeseries.tsv")
+  conf_path <- file.path("sub-01", "func", conf_file)
+  conf_data <- list()
+  conf_data[[conf_path]] <- tibble::tibble(motion_x = c(0.1,0.2), motion_y = c(0.2,0.3))
+
+  tmp_dir <- tempfile("bids_")
+  dir.create(tmp_dir, recursive = TRUE)
+  bidser::create_mock_bids(
+    project_name = "Mock",
+    participants = participants_df,
+    file_structure = file_structure_df,
+    event_data = event_data,
+    confound_data = conf_data,
+    create_stub = TRUE,
+    stub_path = tmp_dir
+  )
+  tmp_dir
+}
+
+write_yaml <- function(lst, path) yaml::write_yaml(lst, path)
+
+
+test_that("confound groups resolve and baseline passes", {
+  bids_dir <- create_temp_bids205()
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = bids_dir, subjects = list(include = "sub-01"), tasks = c("taskA")),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(cond = list(bids_column = "cond", role = "Factor")),
+    confound_groups = list(motion = list(select_by_pattern = c("motion_.*"))),
+    terms = list(t1 = list(type = "EventRelated", event_variables = list("cond"))),
+    models = list(list(name="m1", terms=list("t1"), baseline=list(include_confound_groups=list("motion"))))
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf), add = TRUE)
+
+  expect_no_error(LF(tf))
+})
+
+test_that("undefined confound group triggers error", {
+  bids_dir <- create_temp_bids205()
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = bids_dir, subjects = list(include = "sub-01"), tasks = c("taskA")),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(cond = list(bids_column = "cond", role = "Factor")),
+    terms = list(t1 = list(type = "EventRelated", event_variables = list("cond"))),
+    models = list(list(name="m1", terms=list("t1"), baseline=list(include_confound_groups=list("missing"))))
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf), add = TRUE)
+
+  expect_error(LF(tf), "Confound group 'missing'")
+})
+
+test_that("confound group with no matches errors", {
+  bids_dir <- create_temp_bids205()
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = bids_dir, subjects = list(include = "sub-01"), tasks = c("taskA")),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(cond = list(bids_column = "cond", role = "Factor")),
+    confound_groups = list(nomatch = list(select_by_pattern = c("bad.*"))),
+    terms = list(t1 = list(type = "EventRelated", event_variables = list("cond"))),
+    models = list(list(name="m1", terms=list("t1"), baseline=list(include_confound_groups=list("nomatch")))),
+    validation_settings = list(bids_content_checks="Error")
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf), add = TRUE)
+
+  expect_error(LF(tf), "nomatch")
+})
+


### PR DESCRIPTION
## Summary
- implement DSL-205 confound group validation in `build_config_from_ior`
- add unit tests for confound group resolution and baseline checks

## Testing
- `devtools::test()` *(fails: R not installed)*