### PR TITLE
Implement ls_svd_engine

### DIFF
--- a/R/ls_svd_engine.R
+++ b/R/ls_svd_engine.R
@@ -1,0 +1,70 @@
+#' LS+SVD Rank-1 HRF Estimation Engine
+#'
+#' Internal helper implementing the LS+SVD algorithm described in
+#' `data-raw/LSS+SVD_proposal.md`. The design matrices should already
+#' be projected to the confound null space.
+#'
+#' @param X_list_proj list of k design matrices (n x d each)
+#' @param Y_proj      numeric matrix of projected BOLD data (n x v)
+#' @param lambda_init ridge penalty for initial GLM solve
+#' @param h_ref_shape_norm optional reference HRF shape for sign alignment
+#' @param svd_backend currently ignored, placeholder for future backends
+#' @param epsilon_svd tolerance for singular value screening
+#' @param epsilon_scale tolerance for scale in identifiability step
+#' @return list with matrices `h` (d x v), `beta` (k x v) and
+#'         `Gamma_hat` (d*k x v)
+#' @keywords internal
+#' @noRd
+ls_svd_engine <- function(X_list_proj, Y_proj, lambda_init = 1, 
+                          h_ref_shape_norm = NULL,
+                          svd_backend = c("base_R"),
+                          epsilon_svd = 1e-8,
+                          epsilon_scale = 1e-8) {
+  svd_backend <- match.arg(svd_backend)
+  stopifnot(is.list(X_list_proj), length(X_list_proj) >= 1)
+  n <- nrow(Y_proj)
+  v <- ncol(Y_proj)
+  d <- ncol(X_list_proj[[1]])
+  k <- length(X_list_proj)
+  for (X in X_list_proj) {
+    if (nrow(X) != n) stop("Design matrices must have same rows as Y_proj")
+    if (ncol(X) != d) stop("All design matrices must have the same column count")
+  }
+
+  Xbig <- do.call(cbind, X_list_proj)
+  XtX  <- crossprod(Xbig)
+  Xty  <- crossprod(Xbig, Y_proj)
+  XtX_ridge <- XtX + lambda_init * diag(ncol(Xbig))
+  Gamma_hat <- chol2inv(chol(XtX_ridge)) %*% Xty
+
+  H_out <- matrix(0.0, d, v)
+  B_out <- matrix(0.0, k, v)
+
+  for (vx in seq_len(v)) {
+    G_vx <- matrix(Gamma_hat[, vx], nrow = d, ncol = k)
+    sv <- svd(G_vx, nu = 1, nv = 1)
+    if (length(sv$d) && sv$d[1] > epsilon_svd) {
+      s1 <- sqrt(sv$d[1])
+      H_out[, vx] <- sv$u[, 1] * s1
+      B_out[, vx] <- sv$v[, 1] * s1
+    }
+  }
+
+  scl <- apply(abs(H_out), 2, max)
+  flip <- rep(1.0, v)
+  if (!is.null(h_ref_shape_norm)) {
+    align <- as.numeric(crossprod(h_ref_shape_norm, H_out))
+    flip[align < 0 & scl > epsilon_scale] <- -1.0
+  }
+  eff_scl <- pmax(scl, epsilon_scale)
+  H_final <- sweep(H_out, 2, flip / eff_scl, "*")
+  B_final <- sweep(B_out, 2, flip * eff_scl, "*")
+  zero_idx <- scl <= epsilon_scale
+  if (any(zero_idx)) {
+    H_final[, zero_idx] <- 0
+    B_final[, zero_idx] <- 0
+  }
+
+  list(h = H_final, beta = B_final, Gamma_hat = Gamma_hat)
+}
+

--- a/tests/testthat/test-ls_svd_engine.R
+++ b/tests/testthat/test-ls_svd_engine.R
@@ -1,0 +1,27 @@
+library(testthat)
+
+context("ls_svd_engine")
+
+simple_ls_svd_data <- function() {
+  set.seed(123)
+  n <- 50
+  d <- 3
+  k <- 2
+  v <- 5
+  h_true <- matrix(rnorm(d * v), d, v)
+  beta_true <- matrix(rnorm(k * v), k, v)
+  X_list <- lapply(seq_len(k), function(i) matrix(rnorm(n * d), n, d))
+  Xbig <- do.call(cbind, X_list)
+  Y <- Xbig %*% as.vector(matrix(h_true, d, v) %*% t(beta_true))
+  Y <- matrix(Y, n, v)
+  list(X_list = X_list, Y = Y, d = d, k = k)
+}
+
+
+test_that("ls_svd_engine returns matrices with correct dimensions", {
+  dat <- simple_ls_svd_data()
+  res <- ls_svd_engine(dat$X_list, dat$Y, lambda_init = 0)
+  expect_equal(dim(res$h), c(dat$d, ncol(dat$Y)))
+  expect_equal(dim(res$beta), c(dat$k, ncol(dat$Y)))
+  expect_equal(dim(res$Gamma_hat), c(dat$d * dat$k, ncol(dat$Y)))
+})


### PR DESCRIPTION
## Summary
- add LS+SVD engine implementation
- test dimension outputs of ls_svd_engine

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: `bash: R: command not found`)*