### PR TITLE
Implement DSL-301 config build

### DIFF
--- a/tests/testthat/test-dsl-301.R
+++ b/tests/testthat/test-dsl-301.R
@@ -1,0 +1,71 @@
+library(testthat)
+
+skip_if_not_installed("bidser")
+
+LF <- fmrireg::load_fmri_config
+
+create_temp_bids301 <- function() {
+  participants_df <- tibble::tibble(participant_id = "01", age = 30)
+  file_structure_df <- tibble::tribble(
+    ~subid, ~session, ~datatype, ~task,   ~run, ~suffix,                    ~fmriprep,
+    "01",   NA,       "func",    "taskA", "01", "bold",                   FALSE,
+    "01",   NA,       "func",    "taskA", "01", "events",                 FALSE,
+    "01",   NA,       "func",    "taskA", "01", "desc-confounds_timeseries", TRUE
+  )
+
+  ev_file <- bidser:::generate_bids_filename(subid="01", task="taskA", run="01", suffix="events.tsv")
+  ev_path <- file.path("sub-01", "func", ev_file)
+  event_data <- list()
+  event_data[[ev_path]] <- tibble::tibble(
+    onset = c(1, 3),
+    duration = c(1, 1),
+    cond = c("a", "b"),
+    run = c(1, 1)
+  )
+
+  conf_file <- bidser:::generate_bids_filename(subid="01", task="taskA", run="01", suffix="desc-confounds_timeseries.tsv")
+  conf_path <- file.path("sub-01", "func", conf_file)
+  conf_data <- list()
+  conf_data[[conf_path]] <- tibble::tibble(motion_x = c(0.1,0.2), motion_y = c(0.2,0.3))
+
+  tmp_dir <- tempfile("bids_")
+  dir.create(tmp_dir, recursive = TRUE)
+  bidser::create_mock_bids(
+    project_name = "Mock",
+    participants = participants_df,
+    file_structure = file_structure_df,
+    event_data = event_data,
+    confound_data = conf_data,
+    create_stub = TRUE,
+    stub_path = tmp_dir
+  )
+  tmp_dir
+}
+
+write_yaml <- function(lst, path) yaml::write_yaml(lst, path)
+
+
+test_that("fmri_config contains expected info", {
+  bids_dir <- create_temp_bids301()
+  on.exit(unlink(bids_dir, recursive = TRUE), add = TRUE)
+  tf <- tempfile(fileext = ".yml")
+  cfg <- list(
+    dataset = list(path = bids_dir, subjects = list(include = "sub-01"), tasks = c("taskA")),
+    events = list(onset_column = "onset", duration_column = "duration", block_column = "run"),
+    variables = list(cond = list(bids_column = "cond", role = "Factor"), motion = list(bids_column = "motion_x", role = "NuisanceSource")),
+    confound_groups = list(motion = list(select_by_pattern = c("motion_.*"))),
+    terms = list(t1 = list(type = "EventRelated", event_variables = list("cond"))),
+    models = list(list(name="m1", terms=list("t1"), baseline=list(include_confound_groups=list("motion"))))
+  )
+  write_yaml(cfg, tf)
+  on.exit(unlink(tf), add = TRUE)
+
+  config <- LF(tf)
+  expect_s3_class(config, "fmri_config")
+  expect_true(config$validated)
+  expect_equal(sort(config$events_info$columns), sort(c("onset","duration","cond","run")))
+  expect_equal(config$events_info$mapping$onset_column, "onset")
+  expect_equal(config$confounds_info$groups$motion, c("motion_x","motion_y"))
+  expect_true("cond" %in% config$variable_roles$Factor)
+  expect_true("motion" %in% config$variable_roles$NuisanceSource)
+})


### PR DESCRIPTION
## Summary
- include events and confounds metadata in `fmri_config`
- store variable roles when building the configuration
- test that `load_fmri_config` builds an `fmri_config` object with these fields

## Testing
- `devtools::test()` *(fails: `R` not available)*