### PR TITLE
Add CFALS output object methods

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -477,3 +477,8 @@ export(penalty_matrix)
 S3method(penalty_matrix,HRF)
 export(project_confounds)
 export(fmrireg_hrf_cfals)
+
+S3method(print,fmrireg_cfals_fit)
+S3method(summary,fmrireg_cfals_fit)
+S3method(residuals,fmrireg_cfals_fit)
+S3method(plot,fmrireg_cfals_fit)

--- a/R/cfals_methods.R
+++ b/R/cfals_methods.R
@@ -1,0 +1,42 @@
+#' Methods for fmrireg_cfals_fit Objects
+#'
+#' Basic utilities for inspecting the results
+#' of `fmrireg_hrf_cfals`.
+#'
+#' @param x,object An `fmrireg_cfals_fit` object.
+#' @param vox Index of the voxel to plot.
+#' @param ... Additional arguments passed to underlying functions.
+#' @export
+print.fmrireg_cfals_fit <- function(x, ...) {
+  cat("\nfmrireg CF-ALS Fit\n")
+  cat("==================\n")
+  info <- x$design_info
+  cat(sprintf("Voxels: %d\n", info$v))
+  cat(sprintf("Time points: %d\n", info$n))
+  cat(sprintf("Conditions: %d\n", info$k))
+  cat(sprintf("Basis functions: %d\n", info$d))
+  invisible(x)
+}
+
+#' @export
+summary.fmrireg_cfals_fit <- function(object, ...) {
+  res <- list(r2 = object$gof_per_voxel,
+              design = object$design_info,
+              lambdas = object$lambda_used)
+  class(res) <- "summary.fmrireg_cfals_fit"
+  res
+}
+
+#' @export
+residuals.fmrireg_cfals_fit <- function(object, ...) {
+  object$residuals
+}
+
+#' @export
+plot.fmrireg_cfals_fit <- function(x, vox = 1, ...) {
+  if (vox < 1 || vox > ncol(x$reconstructed_hrfs))
+    stop("'vox' out of range")
+  hrf <- x$reconstructed_hrfs[, vox]
+  plot(hrf, type = "l", xlab = "Time index", ylab = "Amplitude",
+       main = paste("Reconstructed HRF - voxel", vox), ...)
+}


### PR DESCRIPTION
## Summary
- enhance `fmrireg_hrf_cfals` to return reconstructed HRFs, residuals and R²
- add S3 methods for `fmrireg_cfals_fit` objects (print, summary, residuals, plot)
- register new S3 methods in `NAMESPACE`

## Testing
- `R` was not available so `devtools::test()` could not be run