### PR TITLE
Implement CFALS design helpers

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -476,6 +476,7 @@ S3method(reconstruction_matrix,HRF)
 export(penalty_matrix)
 S3method(penalty_matrix,HRF)
 export(project_confounds)
+export(create_fmri_design)
 export(fmrireg_hrf_cfals)
 
 S3method(print,fmrireg_cfals_fit)

--- a/R/cfals_design_utils.R
+++ b/R/cfals_design_utils.R
@@ -49,15 +49,73 @@ penalty_matrix.HRF <- function(hrf) {
 
 #' Project design and data matrices to the null space of confounds
 #'
-#' @param X_list A list of design matrices.
-#' @param Y Data matrix with matching rows.
+#' Projects both the data matrix `Y` and each design matrix in
+#' `X_list` using QR decomposition of the confound matrix.  The
+#' projection can optionally use LAPACK's QR implementation for
+#' improved numerical stability.
+#'
+#' @param Y Numeric matrix of BOLD data (time points \eqn{\times}
+#'   voxels).
+#' @param X_list A list of design matrices with the same number of
+#'   rows as `Y`.
 #' @param confounds Optional confound matrix with matching rows.
+#' @param lapack_qr Logical; passed to `qr()` as the `LAPACK`
+#'   argument.
 #' @return A list with projected `X_list` and `Y` matrices.
 #' @export
-project_confounds <- function(X_list, Y, confounds = NULL) {
-  if (is.null(confounds)) return(list(X_list = X_list, Y = Y))
-  qrZ <- qr(confounds)
+project_confounds <- function(Y, X_list, confounds = NULL, lapack_qr = TRUE) {
+  if (is.null(confounds)) {
+    return(list(X_list = X_list, Y = Y))
+  }
+  qrZ <- qr(confounds, LAPACK = lapack_qr)
   Xp <- lapply(X_list, function(X) qr.resid(qrZ, X))
   Yp <- qr.resid(qrZ, Y)
   list(X_list = Xp, Y = Yp)
+}
+
+#' Create design matrices for CFALS estimation
+#'
+#' Convenience helper that constructs the list of design matrices for
+#' a given `event_model` and HRF basis.  It also returns useful
+#' metadata such as the number of basis functions and conditions as
+#' well as a reconstruction matrix for converting HRF coefficients to
+#' sampled shapes and a normalised reference HRF vector for sign
+#' alignment.
+#'
+#' @param event_model An object of class `event_model`.
+#' @param hrf_basis An `HRF` basis object.
+#' @return A list with elements `X_list`, `d`, `k`, `Phi`, and
+#'   `h_ref_shape_norm`.
+#' @export
+create_fmri_design <- function(event_model, hrf_basis) {
+  if (!inherits(event_model, "event_model")) {
+    stop("'event_model' must be an 'event_model' object")
+  }
+  if (!inherits(hrf_basis, "HRF")) {
+    stop("'hrf_basis' must be an object of class 'HRF'")
+  }
+
+  sframe <- event_model$sampling_frame
+  sample_times <- samples(sframe, global = TRUE)
+
+  reg_lists <- lapply(event_model$terms, regressors.event_term,
+                      hrf = hrf_basis,
+                      sampling_frame = sframe,
+                      summate = FALSE,
+                      drop.empty = TRUE)
+  regs <- unlist(reg_lists, recursive = FALSE)
+  cond_names <- names(regs)
+  X_list <- lapply(regs, function(r)
+    evaluate(r, sample_times, precision = sframe$precision))
+  names(X_list) <- cond_names
+
+  Phi <- reconstruction_matrix(hrf_basis, sframe)
+  h_ref <- drop(Phi[, 1])
+  h_ref <- h_ref / max(abs(h_ref))
+
+  list(X_list = X_list,
+       d = nbasis(hrf_basis),
+       k = length(X_list),
+       Phi = Phi,
+       h_ref_shape_norm = h_ref)
 }

--- a/tests/testthat/test-cfals_design_utils.R
+++ b/tests/testthat/test-cfals_design_utils.R
@@ -16,7 +16,23 @@ test_that("project_confounds projects via QR", {
   X <- matrix(rnorm(20), 5, 4)
   Y <- matrix(rnorm(10), 5, 2)
   Z <- matrix(seq_len(5), ncol = 1)
-  res <- project_confounds(list(X), Y, Z)
+  res <- project_confounds(Y, list(X), Z)
   expect_equal(dim(res$X_list[[1]]), dim(X))
   expect_equal(dim(res$Y), dim(Y))
+})
+
+test_that("create_fmri_design returns expected structure", {
+  sf <- sampling_frame(20, TR = 1)
+  events <- data.frame(onset = c(2, 6, 12),
+                       condition = factor(c("A", "B", "A")),
+                       block = 1)
+  emod <- event_model(onset ~ hrf(condition), data = events,
+                      block = ~ block, sampling_frame = sf)
+  des <- create_fmri_design(emod, HRF_SPMG1)
+  expect_type(des, "list")
+  expect_equal(length(des$X_list), 2)
+  expect_equal(des$d, nbasis(HRF_SPMG1))
+  expect_equal(des$k, length(des$X_list))
+  expect_true(is.matrix(des$Phi))
+  expect_true(is.numeric(des$h_ref_shape_norm))
 })


### PR DESCRIPTION
## Summary
- add `create_fmri_design` helper and expand `project_confounds`
- use new helpers inside `fmrireg_hrf_cfals`
- export new function in NAMESPACE
- update design utils tests

## Testing
- `devtools::test()` *(fails: Rscript not found)*