### PR TITLE
Add DSL2-503 helper to assemble fmri_model

### DIFF
--- a/R/fmridsl_builder.R
+++ b/R/fmridsl_builder.R
@@ -839,3 +839,20 @@ build_event_model_from_dsl <- function(term_specs,
               sampling_frame = sframe,
               durations = data_df$duration)
 }
+
+#' Assemble fmri_model from event and baseline components
+#'
+#' Implements DSL2-503. This helper simply calls [fmri_model()]
+#' to combine an `event_model` and a `baseline_model` into a
+#' full `fmri_model` object.
+#'
+#' @param event_model An `event_model` object.
+#' @param baseline_model A `baseline_model` object.
+#' @return An `fmri_model` object.
+#' @keywords internal
+build_fmri_model_from_dsl <- function(event_model, baseline_model) {
+  stopifnot(inherits(event_model, "event_model"))
+  stopifnot(inherits(baseline_model, "baseline_model"))
+  fmri_model(event_model, baseline_model)
+}
+

--- a/tests/testthat/test-dsl2-503-fmri-model.R
+++ b/tests/testthat/test-dsl2-503-fmri-model.R
@@ -1,0 +1,24 @@
+skip_if_not_installed("bidser")
+
+BF <- fmrireg:::build_fmri_model_from_dsl
+
+# Simple helper to create dummy models
+create_dummy_models <- function() {
+  sframe <- sampling_frame(blocklens = c(2), TR = 2)
+  ev_mod <- event_model(~ hrf(cond),
+                        data = data.frame(onset = c(1),
+                                           duration = c(1),
+                                           cond = factor("a"),
+                                           block = 1),
+                        block = ~ block,
+                        sampling_frame = sframe,
+                        durations = 1)
+  bl_mod <- baseline_model(basis = "constant", sframe = sframe)
+  list(ev_mod = ev_mod, bl_mod = bl_mod)
+}
+
+test_that("fmri_model assembled from components", {
+  mods <- create_dummy_models()
+  fm <- BF(mods$ev_mod, mods$bl_mod)
+  expect_s3_class(fm, "fmri_model")
+})


### PR DESCRIPTION
## Summary
- add `build_fmri_model_from_dsl()` implementing DSL2-503
- add test for assembling an `fmri_model`

## Testing
- `R -q -e "devtools::test()"` *(fails: command not found)*