### PR TITLE
Implement fmrireg CFALS fit object

### DIFF
--- a/R/cfals_methods.R
+++ b/R/cfals_methods.R
@@ -1,3 +1,37 @@
+#' Construct an \code{fmrireg_cfals_fit} object
+#'
+#' Simple constructor used by [fmrireg_cfals()] to package the
+#' results returned by the various CFALS engines.
+#'
+#' @param h_coeffs Matrix of HRF basis coefficients (d \eqn{\times} v).
+#' @param beta_amps Matrix of condition amplitudes (k \eqn{\times} v).
+#' @param method Character string indicating the estimation method.
+#' @param lambdas Numeric vector of regularisation parameters.
+#' @param call The matched call to the wrapper function.
+#' @param hrf_basis HRF basis object used for the estimation.
+#' @param design_info List with design metadata (d, k, n, v, fullXtX).
+#' @param residuals Residual matrix from the projected data fit.
+#' @param recon_hrf Matrix of reconstructed HRF shapes.
+#' @param gof Numeric vector of goodness-of-fit statistics per voxel.
+#' @return An object of class \code{fmrireg_cfals_fit}.
+#' @keywords internal
+fmrireg_cfals_fit <- function(h_coeffs, beta_amps, method, lambdas, call,
+                              hrf_basis, design_info, residuals,
+                              recon_hrf = NULL, gof = NULL) {
+  out <- list(h_coeffs = h_coeffs,
+              beta_amps = beta_amps,
+              method_used = method,
+              lambdas = lambdas,
+              call = call,
+              hrf_basis_used = hrf_basis,
+              design_info = design_info,
+              residuals = residuals,
+              reconstructed_hrfs = recon_hrf,
+              gof_per_voxel = gof)
+  class(out) <- c("fmrireg_cfals_fit", "list")
+  out
+}
+
 #' Methods for fmrireg_cfals_fit Objects
 #'
 #' Basic utilities for inspecting the results
@@ -22,7 +56,7 @@ print.fmrireg_cfals_fit <- function(x, ...) {
 summary.fmrireg_cfals_fit <- function(object, ...) {
   res <- list(r2 = object$gof_per_voxel,
               design = object$design_info,
-              lambdas = object$lambda_used)
+              lambdas = object$lambdas)
   class(res) <- "summary.fmrireg_cfals_fit"
   res
 }

--- a/R/cfals_wrapper.R
+++ b/R/cfals_wrapper.R
@@ -98,22 +98,22 @@ fmrireg_cfals <- function(fmri_data_obj,
   SSE <- colSums(resids^2)
   r2 <- 1 - SSE / SST
 
-  out <- list(h = fit$h,
-              beta = fit$beta,
-              reconstructed_hrfs = recon_hrf,
-              residuals = resids,
-              gof_per_voxel = r2,
-              hrf_basis_used = hrf_basis,
-              lambda_used = c(init = lambda_init,
-                               beta = lambda_b,
-                               h = lambda_h),
-              design_info = list(d = design$d,
-                                 k = length(X_list),
-                                 n = n,
-                                 v = v,
-                                 fullXtX = fullXtX),
-              method_used = method)
-  class(out) <- c("fmrireg_cfals_fit", "list")
+  out <- fmrireg_cfals_fit(h_coeffs = fit$h,
+                           beta_amps = fit$beta,
+                           method = method,
+                           lambdas = c(init = lambda_init,
+                                       beta = lambda_b,
+                                       h = lambda_h),
+                           call = match.call(),
+                           hrf_basis = hrf_basis,
+                           design_info = list(d = design$d,
+                                              k = length(X_list),
+                                              n = n,
+                                              v = v,
+                                              fullXtX = fullXtX),
+                           residuals = resids,
+                           recon_hrf = recon_hrf,
+                           gof = r2)
   out
 }
 

--- a/tests/testthat/test-cfals-wrapper.R
+++ b/tests/testthat/test-cfals-wrapper.R
@@ -43,9 +43,9 @@ test_that("fmrireg_hrf_cfals works across HRF bases", {
     dat <- simulate_cfals_wrapper_data(b)
     fit <- fmrireg_hrf_cfals(dat$Y, dat$event_model, b,
                              lam_beta = 0.1, lam_h = 0.1)
-    expect_equal(dim(fit$h), c(nbasis(b), ncol(dat$Y)))
-    expect_equal(dim(fit$beta), c(length(dat$X_list), ncol(dat$Y)))
-    recon <- reconstruction_matrix(b, dat$sframe) %*% fit$h
+    expect_equal(dim(fit$h_coeffs), c(nbasis(b), ncol(dat$Y)))
+    expect_equal(dim(fit$beta_amps), c(length(dat$X_list), ncol(dat$Y)))
+    recon <- reconstruction_matrix(b, dat$sframe) %*% fit$h_coeffs
     expect_true(all(is.finite(recon)))
   }
 })
@@ -57,8 +57,8 @@ test_that("fmrireg_cfals wrapper supports multiple methods", {
     fit <- fmrireg_cfals(dat$Y, dat$event_model, HRF_SPMG3,
                          method = m, lambda_b = 0.1, lambda_h = 0.1,
                          lambda_init = 0.5, max_alt = 1)
-    expect_equal(dim(fit$h), c(nbasis(HRF_SPMG3), ncol(dat$Y)))
-    expect_equal(dim(fit$beta), c(length(dat$X_list), ncol(dat$Y)))
+    expect_equal(dim(fit$h_coeffs), c(nbasis(HRF_SPMG3), ncol(dat$Y)))
+    expect_equal(dim(fit$beta_amps), c(length(dat$X_list), ncol(dat$Y)))
   }
 })
 


### PR DESCRIPTION
## Summary
- add `fmrireg_cfals_fit()` constructor and update methods
- refactor `fmrireg_cfals()` wrapper to use the new object
- adjust wrapper tests for renamed slots

## Testing
- `R` commands were not run because the environment lacks an R installation