### PR TITLE
Enhance fmri_betas modularity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,6 +63,7 @@ Suggests:
     forecast,
     shiny,
     mgcv,
+    progressr,
     ggforce,
     roxyglobals (>= 0.2.1),
     bidser
@@ -95,6 +96,7 @@ Collate:
     'event_vector.R'
     'find_hrf.R'
     'fmri_betas.R'
+    'beta_utils.R'
     'fmri_dataset.R'
     'fmri_group_dataset.R'
     'fmri_latent_lm.R'

--- a/R/beta_utils.R
+++ b/R/beta_utils.R
@@ -1,0 +1,32 @@
+#' @keywords internal
+#' @noRd
+build_design_data <- function(bdes) {
+  X <- if (is.null(bdes$dmat_fixed)) bdes$dmat_ran else cbind(bdes$dmat_ran, bdes$dmat_fixed)
+  Base <- as.matrix(bdes$dmat_base)
+  X[is.na(X)] <- 0
+  list(Base = Base, X = X)
+}
+
+#' @keywords internal
+#' @noRd
+masked_vectors <- function(dset) {
+  neuroim2::vectors(get_data(dset), subset = which(get_mask(dset) > 0))
+}
+
+#' Apply a function to voxel vectors with optional progress bar
+#'
+#' @keywords internal
+#' @noRd
+map_voxels <- function(vecs, FUN, ..., .progress = TRUE) {
+  worker <- function(v) FUN(v, ...)
+  if (.progress) {
+    with_package("progressr")
+    progressr::with_progress({
+      p <- progressr::progressor(along = vecs)
+      res <- furrr::future_map(vecs, function(v) { p(); worker(v) })
+    })
+  } else {
+    res <- furrr::future_map(vecs, worker)
+  }
+  do.call(cbind, res)
+}


### PR DESCRIPTION
## Summary
- refactor `fmri_betas.R` for better modularity
- add `beta_utils.R` utilities for design prep, masked voxel access and progress-enabled mapping
- add progress support to beta estimation and HRF estimation
- add progressr to Suggests and collate new utils

## Testing
- `R` not available so no tests were run