### PR TITLE
Refactor robust modeling wrappers

### DIFF
--- a/man/chunkwise_rlm.Rd
+++ b/man/chunkwise_rlm.Rd
@@ -4,16 +4,30 @@
 \alias{chunkwise_rlm}
 \title{Perform Chunkwise Robust Linear Modeling on fMRI Dataset}
 \usage{
-chunkwise_rlm(dset, model, conlist, fcon, nchunks, verbose = FALSE)
+chunkwise_rlm(
+  dset,
+  model,
+  contrast_objects,
+  nchunks,
+  verbose = FALSE,
+  use_fast_path = FALSE,
+  progress = FALSE
+)
 }
 \arguments{
 \item{dset}{An \code{fmri_dataset} object.}
 
 \item{model}{The \code{fmri_model} used for the analysis.}
 
+\item{contrast_objects}{The list of full contrast objects.}
+
 \item{nchunks}{The number of chunks to divide the dataset into.}
 
 \item{verbose}{Logical. Whether to display progress messages (default is \code{FALSE}).}
+
+\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based fast computation.}
+
+\item{progress}{Logical. Show a progress bar during chunk processing.}
 }
 \description{
 Perform Chunkwise Robust Linear Modeling on fMRI Dataset

--- a/man/fmri_rlm.Rd
+++ b/man/fmri_rlm.Rd
@@ -13,7 +13,6 @@ fmri_rlm(
   drop_empty = TRUE,
   strategy = c("runwise", "chunkwise"),
   nchunks = 10,
-  meta_weighting = c("inv_var", "equal"),
   ...
 )
 }
@@ -33,8 +32,6 @@ fmri_rlm(
 \item{strategy}{The data splitting strategy, either \code{"runwise"} or \code{"chunkwise"}. Default is \code{"runwise"}.}
 
 \item{nchunks}{Number of data chunks when strategy is "chunkwise". Default is 10.}
-
-\item{meta_weighting}{Method for combining results across runs/chunks. Either "inv_var" for inverse variance weighting or "equal" for equal weighting. Default is "inv_var".}
 
 \item{...}{Additional arguments.}
 }

--- a/man/runwise_rlm.Rd
+++ b/man/runwise_rlm.Rd
@@ -5,19 +5,26 @@
 \title{Perform Runwise Robust Linear Modeling on fMRI Dataset}
 \usage{
 runwise_rlm(
-  dataset,
+  dset,
   model,
-  conlist,
-  fcons,
-  meta_weighting = c("inv_var", "equal"),
+  contrast_objects,
   verbose = FALSE,
-  ...
+  use_fast_path = FALSE,
+  progress = FALSE
 )
 }
 \arguments{
+\item{dset}{An \code{fmri_dataset} object.}
+
 \item{model}{The \code{fmri_model} used for the analysis.}
 
+\item{contrast_objects}{The list of full contrast objects.}
+
 \item{verbose}{Logical. Whether to display progress messages (default is \code{FALSE}).}
+
+\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based fast computation.}
+
+\item{progress}{Logical. Show a progress bar during run processing.}
 }
 \description{
 Perform Runwise Robust Linear Modeling on fMRI Dataset


### PR DESCRIPTION
## Summary
- simplify `fmri_rlm()` to delegate to `fmri_lm(..., robust=TRUE)`
- wrap runwise and chunkwise robust helpers around their LM counterparts
- update documentation for changed arguments

## Testing
- `R` not available: `devtools::test()` failed to run