### PR TITLE
Add CustomR HRF code evaluation

### DIFF
--- a/tests/testthat/test-dsl2-201-get-hrf.R
+++ b/tests/testthat/test-dsl2-201-get-hrf.R
@@ -39,3 +39,10 @@ test_that("CustomR loads function", {
   expect_equal(attr(h, "params")$.lag, 2)
 })
 
+test_that("CustomR evaluates code string", {
+  cfg <- make_cfg(list(custom=list(type="CustomR", definition="function(t) t*0")))
+  h <- GH("custom", cfg)
+  expect_s3_class(h, "HRF")
+  expect_equal(as.numeric(h(0)), 0)
+})
+


### PR DESCRIPTION
## Summary
- extend `get_hrf_from_dsl` to evaluate CustomR HRF definitions
- test for executing code-based CustomR HRFs

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`