### PR TITLE
Fix roxygen issues in bootstrap function

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -1,4 +1,4 @@
-#' Multiresponse Bootstrap Linear Model
+#' Multiresponse bootstrap linear model
 #'
 #' @description
 #' Performs block bootstrap resampling for multiresponse linear models, particularly
@@ -39,14 +39,13 @@
 #' }
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Simple example with synthetic data
 #' X <- model.matrix(~ x1 + x2, data = data.frame(x1 = rnorm(100), x2 = rnorm(100)))
 #' y <- matrix(rnorm(100 * 3), 100, 3)  # 3 response variables
 #' result <- multiresponse_bootstrap_lm(modmat = X, data_env = list(.y = y),
 #'                                     nboot = 100, block_size = 20)
 #' }
-#' @noRd 
 #' @keywords internal
 multiresponse_bootstrap_lm <- function(form, data_env, 
                                      conlist, 
@@ -142,16 +141,13 @@ multiresponse_bootstrap_lm <- function(form, data_env,
   })
   
   # Return results
-  orig <- fit_lm_contrasts(lm.orig, conlist, fcon, vnames) %>% 
+  orig <- fit_lm_contrasts(lm.orig, conlist, fcon, vnames) %>%
     purrr::list_modify(
-      con_cov=con_cov, 
-      beta_cov=beta_cov, 
-      nboot=nboot, 
-      bootstrap=TRUE
-    ) 
-  
+      con_cov = con_cov,
+      beta_cov = beta_cov,
+      nboot = nboot,
+      bootstrap = TRUE
+    )
+
   orig
 }
-
-  
-  


### PR DESCRIPTION
## Summary
- fix sentence case in title
- switch example to \donttest
- keep internal docs using `@keywords internal`
- remove stray text at end of file and tidy arguments

## Testing
- `R` was not available so no tests were run