### PR TITLE
Document ellipsis parameter for baseline term matrix

### DIFF
--- a/R/baseline_model.R
+++ b/R/baseline_model.R
@@ -422,6 +422,7 @@ baseline_term <- function(varname, mat, colind, rowind) {
 #' @param x A `baseline_term` object.
 #' @param blockid Optional block identifier to subset rows.
 #' @param allrows Logical; if `TRUE`, return all rows for the selected block.
+#' @param ... Additional arguments (currently unused).
 #' @return A tibble containing baseline regressors.
 #' @examples
 #' sframe <- sampling_frame(blocklens = 10, TR = 1)


### PR DESCRIPTION
## Summary
- document the ellipsis argument in `design_matrix.baseline_term`
- attempted to run `devtools::document()` but `R` isn't available in the environment

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*