### PR TITLE
Add FFT size limit check

### DIFF
--- a/R/reg-methods.R
+++ b/R/reg-methods.R
@@ -10,7 +10,8 @@
 #' @param precision Numeric sampling precision for internal HRF evaluation and convolution (seconds).
 #' @param method The evaluation method: 
 #'   \itemize{
-#'     \item{"fft"}{ (Default) Uses the fast C++ FFT convolution (`evaluate_regressor_fast`). Generally recommended.}
+#'     \item{"fft"}{ (Default) Uses the fast C++ FFT convolution (`evaluate_regressor_fast`). Generally recommended.  
+#'       Extremely fine `precision` or wide `grid` ranges may trigger an internal FFT size exceeding ~1e7, which results in an error.}
 #'     \item{"conv"}{ Uses the C++ direct convolution (`evaluate_regressor_convolution`).}
 #'     \item{"Rconv"}{ Uses an R-based convolution (`stats::convolve`). Requires constant event durations and a regular sampling grid. Can be faster than the R loop for many events meeting these criteria.}
 #'     \item{"loop"}{ Uses a pure R implementation involving looping through onsets. Can be slower, especially for many onsets.}

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -27,7 +27,8 @@ evaluate(x, grid, ...)
 
 \item{method}{The evaluation method:
 \itemize{
-\item{"fft"}{ (Default) Uses the fast C++ FFT convolution (\code{evaluate_regressor_fast}). Generally recommended.}
+\item{"fft"}{ (Default) Uses the fast C++ FFT convolution (\code{evaluate_regressor_fast}). Generally recommended.
+Extremely fine \code{precision} or wide \code{grid} ranges may trigger an internal FFT size exceeding ~1e7, which results in an error.}
 \item{"conv"}{ Uses the C++ direct convolution (\code{evaluate_regressor_convolution}).}
 \item{"Rconv"}{ Uses an R-based convolution (\code{stats::convolve}). Requires constant event durations and a regular sampling grid. Can be faster than the R loop for many events meeting these criteria.}
 \item{"loop"}{ Uses a pure R implementation involving looping through onsets. Can be slower, especially for many onsets.}

--- a/src/neural_input.cpp
+++ b/src/neural_input.cpp
@@ -297,6 +297,10 @@ SEXP evaluate_regressor_fast(const arma::vec& grid,
                                          t0, t1, dt);
 
     const uword nFFT = nextPow2(neural.n_elem + hrfFine.n_rows);
+    const double max_fft_size = 1e7; // safeguard for extremely large FFTs
+    if (nFFT > max_fft_size) {
+        Rcpp::stop("Requested precision/time range is too fine: FFT size %u exceeds limit of %.0f", nFFT, max_fft_size);
+    }
     arma::cx_vec NeuralFFT = arma::fft(neural, nFFT);
 
     arma::mat out(grid.n_elem, nbasis+1);

--- a/tests/testthat/test-regressor.R
+++ b/tests/testthat/test-regressor.R
@@ -255,7 +255,16 @@ test_that("generate an event model with one observation per level", {
   lopdes$onset <- lopdes$WordPresentationOnset/1000
   lopdes$Target <- factor(lopdes$Target)
   # Suppress warnings specifically for this call, as empty cells might trigger them
-  expect_warning(ev <- event_model(onset ~ hrf(Target), data=lopdes, block= ~ Run, sampling_frame=sframe), 
+  expect_warning(ev <- event_model(onset ~ hrf(Target), data=lopdes, block= ~ Run, sampling_frame=sframe),
                  regexp = NA) # Expect warnings, but don't fail test if they occur
   expect_true(!is.null(ev))
-}) 
+})
+
+test_that("evaluate.Reg errors when FFT size would be huge", {
+  reg <- regressor(onsets = 0, hrf = HRF_SPMG1)
+  grid <- seq(0, 1, by = 1)
+  expect_error(
+    evaluate(reg, grid, precision = 1e-6, method = "fft"),
+    regexp = "FFT size"
+  )
+})


### PR DESCRIPTION
## Summary
- cap FFT length in `evaluate_regressor_fast`
- document new limit in `evaluate()` docs
- test that calling `evaluate()` with extreme precision errors

## Testing
- `devtools::test()` *(fails: `R` not installed)*