### PR TITLE
Add thread configuration option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -119,4 +119,5 @@ Collate:
     'reg-methods.R'
     'regressor.R'
     'sampling_frame.R'
-    'simulate.R'
+    'simulate.R',
+    'zzz.R'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,15 @@
+.onLoad <- function(libname, pkgname) {
+  env_threads <- Sys.getenv("FMRIREG_NUM_THREADS", unset = NA)
+  opt_threads <- getOption("fmrireg.num_threads", default = NA)
+  val <- NA
+  if (!is.na(opt_threads)) {
+    val <- opt_threads
+  } else if (!is.na(env_threads) && nzchar(env_threads)) {
+    val <- as.numeric(env_threads)
+  }
+  if (!is.na(val) && val > 0) {
+    try({
+      RcppParallel::setThreadOptions(numThreads = as.integer(val))
+    }, silent = TRUE)
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ vignettes:
 
 See examples of use of `fmrireg` in the
 [vignettes](https://bbuchsbaum.github.io/fmrireg/articles/index.html).
+
+## Thread configuration
+
+The internal C++ routines use [RcppParallel](https://rcppcore.github.io/RcppParallel/). You can control the number of threads by setting the R option `fmrireg.num_threads` or the environment variable `FMRIREG_NUM_THREADS` before loading the package. If either is set, `fmrireg` calls `RcppParallel::setThreadOptions()` when it loads.
+

--- a/tests/testthat/test_thread_option.R
+++ b/tests/testthat/test_thread_option.R
@@ -1,0 +1,31 @@
+context("Thread configuration")
+
+test_that(".onLoad sets thread count from option", {
+  testthat::local_edition(3)
+  skip_if_not_installed("RcppParallel")
+  old_threads <- RcppParallel::defaultNumThreads()
+  old_opt <- getOption("fmrireg.num_threads")
+  on.exit({
+    options(fmrireg.num_threads = old_opt)
+    RcppParallel::setThreadOptions(numThreads = old_threads)
+  })
+
+  options(fmrireg.num_threads = 2)
+  fmrireg::.onLoad(NULL, NULL)
+  expect_equal(RcppParallel::defaultNumThreads(), 2)
+})
+
+ test_that(".onLoad sets thread count from env var", {
+   skip_if_not_installed("RcppParallel")
+   old_threads <- RcppParallel::defaultNumThreads()
+   old_env <- Sys.getenv("FMRIREG_NUM_THREADS", unset = NA)
+   on.exit({
+     if (is.na(old_env)) Sys.unsetenv("FMRIREG_NUM_THREADS") else Sys.setenv(FMRIREG_NUM_THREADS = old_env)
+     RcppParallel::setThreadOptions(numThreads = old_threads)
+   })
+
+   Sys.setenv(FMRIREG_NUM_THREADS = 3)
+   options(fmrireg.num_threads = NULL)
+   fmrireg::.onLoad(NULL, NULL)
+   expect_equal(RcppParallel::defaultNumThreads(), 3)
+ })

--- a/vignettes/a_09_linear_model.Rmd
+++ b/vignettes/a_09_linear_model.Rmd
@@ -21,6 +21,9 @@ library(doParallel)
 # Set up parallel processing with 1 core
 registerDoParallel(cores = 1)
 
+# Limit RcppParallel threads
+options(fmrireg.num_threads = 2)
+
 set.seed(42)  # For reproducible examples
 ```
 
@@ -33,6 +36,8 @@ Statistical analysis of fMRI data typically involves fitting a linear model to e
 3. Estimating condition-specific effects
 4. Computing contrasts between conditions
 5. Testing statistical hypotheses about brain activity
+
+Thread usage in internal routines can be adjusted globally. Set `options(fmrireg.num_threads = <n>)` or the environment variable `FMRIREG_NUM_THREADS` before loading the package to control how many threads RcppParallel uses.
 
 This vignette demonstrates how to conduct a complete linear model analysis using the `fmrireg` package, from data simulation to statistical inference.
 


### PR DESCRIPTION
## Summary
- allow user configuration of threading with a new `.onLoad()` in `zzz.R`
- document thread control in README and vignette
- add tests for `.onLoad()` thread handling

## Testing
- `R CMD check` *(fails: R not installed)*