### PR TITLE
Implement AR modeling API parameters

### DIFF
--- a/R/fmrirlm.R
+++ b/R/fmrirlm.R
@@ -19,11 +19,16 @@ fmri_rlm <- function(formula, block, baseline_model = NULL, dataset,
                      durations = 0, drop_empty = TRUE,
                      strategy = c("runwise", "chunkwise"),
                      nchunks = 10,
+                     cor_struct = c("iid", "ar1", "ar2", "arp"), cor_iter = 1L,
+                     cor_global = FALSE, ar_p = NULL, ar1_exact_first = FALSE,
                      ...) {
 
   res <- fmri_lm(formula, block, baseline_model = baseline_model, dataset = dataset,
                  durations = durations, drop_empty = drop_empty,
                  strategy = strategy, nchunks = nchunks,
+                 cor_struct = cor_struct, cor_iter = cor_iter,
+                 cor_global = cor_global, ar_p = ar_p,
+                 ar1_exact_first = ar1_exact_first,
                  robust = TRUE, ...)
   class(res) <- c("fmri_rlm", class(res))
   res
@@ -35,10 +40,15 @@ fmri_rlm <- function(formula, block, baseline_model = NULL, dataset,
 #' @keywords internal
 chunkwise_rlm <- function(dset, model, contrast_objects, nchunks,
                           verbose = FALSE, use_fast_path = FALSE,
-                          progress = FALSE) {
+                          progress = FALSE,
+                          cor_struct = c("iid", "ar1", "ar2", "arp"), cor_iter = 1L,
+                          cor_global = FALSE, ar_p = NULL, ar1_exact_first = FALSE) {
   chunkwise_lm.fmri_dataset(dset, model, contrast_objects, nchunks,
                             robust = TRUE, verbose = verbose,
-                            use_fast_path = use_fast_path, progress = progress)
+                            use_fast_path = use_fast_path, progress = progress,
+                            cor_struct = cor_struct, cor_iter = cor_iter,
+                            cor_global = cor_global, ar_p = ar_p,
+                            ar1_exact_first = ar1_exact_first)
 }
 
 #' Perform Runwise Robust Linear Modeling on fMRI Dataset
@@ -47,10 +57,15 @@ chunkwise_rlm <- function(dset, model, contrast_objects, nchunks,
 #' @keywords internal
 runwise_rlm <- function(dset, model, contrast_objects,
                        verbose = FALSE, use_fast_path = FALSE,
-                       progress = FALSE) {
+                       progress = FALSE,
+                       cor_struct = c("iid", "ar1", "ar2", "arp"), cor_iter = 1L,
+                       cor_global = FALSE, ar_p = NULL, ar1_exact_first = FALSE) {
   runwise_lm(dset, model, contrast_objects, robust = TRUE,
              verbose = verbose, use_fast_path = use_fast_path,
-             progress = progress)
+             progress = progress,
+             cor_struct = cor_struct, cor_iter = cor_iter,
+             cor_global = cor_global, ar_p = ar_p,
+             ar1_exact_first = ar1_exact_first)
 }
 
 #' Fit a multiresponse robust linear model

--- a/tests/testthat/test_ar_args.R
+++ b/tests/testthat/test_ar_args.R
@@ -1,0 +1,41 @@
+context("AR argument passing")
+
+options(mc.cores=1)
+
+library(testthat)
+
+# simple synthetic dataset
+etab <- data.frame(onset=c(1,10), repnum=factor(c("A","B")), run=c(1,1))
+Y <- matrix(rnorm(20*5), 20, 5)
+dset <- matrix_dataset(Y, TR=1, run_length=20, event_table=etab)
+
+test_that("fmri_lm accepts AR arguments", {
+  expect_error(
+    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+            cor_struct = "ar1", cor_iter = 2, cor_global = FALSE,
+            ar1_exact_first = TRUE),
+    NA
+  )
+
+  expect_error(
+    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+            strategy = "chunkwise", nchunks = 2,
+            cor_struct = "ar1", cor_iter = 1, cor_global = TRUE,
+            ar1_exact_first = FALSE),
+    NA
+  )
+})
+
+test_that("ar_p validation works", {
+  expect_error(
+    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+            cor_struct = "arp"),
+    "ar_p"
+  )
+
+  expect_error(
+    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+            cor_struct = "arp", ar_p = 2),
+    NA
+  )
+})


### PR DESCRIPTION
## Summary
- add argument placeholders for AR modeling in `fmri_lm`
- thread AR arguments through `fmri_lm_fit`, `runwise_lm`, and `chunkwise_lm`
- expose same parameters in `fmri_rlm`
- add unit tests covering new argument validation

## Testing
- ❌ `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` (failed: `Rscript: command not found`)
