### PR TITLE
Implement C++ AR whitening filter

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,3 +33,7 @@ evaluate_regressor_cpp <- function(grid, onsets, durations, amplitudes, hrf_matr
     .Call('_fmrireg_evaluate_regressor_cpp', PACKAGE = 'fmrireg', grid, onsets, durations, amplitudes, hrf_matrix, hrf_span, precision, method)
 }
 
+ar_whiten_inplace <- function(Y, X, phi_coeffs, exact_first_ar1 = FALSE) {
+    .Call('_fmrireg_ar_whiten_inplace', PACKAGE = 'fmrireg', Y, X, phi_coeffs, exact_first_ar1)
+}
+

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -28,6 +28,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// ar_whiten_inplace
+void ar_whiten_inplace(Rcpp::NumericMatrix Y, Rcpp::NumericMatrix X, const arma::vec& phi_coeffs, bool exact_first_ar1 = false);
+RcppExport SEXP _fmrireg_ar_whiten_inplace(SEXP YSEXP, SEXP XSEXP, SEXP phi_coeffsSEXP, SEXP exact_first_ar1SEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type Y(YSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type X(XSEXP);
+    Rcpp::traits::input_parameter< const arma::vec& >::type phi_coeffs(phi_coeffsSEXP);
+    Rcpp::traits::input_parameter< bool >::type exact_first_ar1(exact_first_ar1SEXP);
+    ar_whiten_inplace(Y, X, phi_coeffs, exact_first_ar1);
+    rcpp_result_gen = R_NilValue;
+    return rcpp_result_gen;
+END_RCPP
+}
 // compute_residuals_cpp
 List compute_residuals_cpp(const arma::mat& X_base_fixed, const arma::mat& data_matrix, const arma::mat& dmat_ran);
 RcppExport SEXP _fmrireg_compute_residuals_cpp(SEXP X_base_fixedSEXP, SEXP data_matrixSEXP, SEXP dmat_ranSEXP) {
@@ -149,6 +164,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_fmrireg_evaluate_regressor_convolution", (DL_FUNC) &_fmrireg_evaluate_regressor_convolution, 9},
     {"_fmrireg_evaluate_regressor_fast", (DL_FUNC) &_fmrireg_evaluate_regressor_fast, 7},
     {"_fmrireg_evaluate_regressor_cpp", (DL_FUNC) &_fmrireg_evaluate_regressor_cpp, 8},
+    {"_fmrireg_ar_whiten_inplace", (DL_FUNC) &_fmrireg_ar_whiten_inplace, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/ar_whiten.cpp
+++ b/src/ar_whiten.cpp
@@ -1,0 +1,61 @@
+#include <RcppArmadillo.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+// [[Rcpp::depends(RcppArmadillo)]]
+
+using namespace Rcpp;
+using namespace arma;
+
+// internal helper operating on Armadillo views of R matrices
+static void ar_whiten_matrix(arma::mat& M, const arma::vec& phi, bool exact_first_ar1) {
+    const arma::uword n_time = M.n_rows;
+    const arma::uword n_cols = M.n_cols;
+    const arma::uword p = phi.n_elem;
+
+    #pragma omp parallel for
+    for (arma::uword col = 0; col < n_cols; ++col) {
+        std::vector<double> prev(p, 0.0);
+        double scale = 1.0;
+        if (exact_first_ar1 && p == 1) {
+            scale = std::sqrt(1.0 - phi[0] * phi[0]);
+        }
+        for (arma::uword t = 0; t < n_time; ++t) {
+            double orig = M(t, col);
+            double val = orig;
+            for (arma::uword k = 0; k < p; ++k) {
+                val -= phi[k] * prev[k];
+            }
+            if (t == 0 && exact_first_ar1 && p == 1) {
+                val *= scale;
+            }
+            if (p > 0) {
+                for (int k = p - 1; k > 0; --k) {
+                    prev[k] = prev[k - 1];
+                }
+                if (p > 0) prev[0] = orig;
+            }
+            M(t, col) = val;
+        }
+    }
+}
+
+//' AR(p) whitening of data and design matrices
+//'
+//' Applies a causal AR filter defined by `phi_coeffs` to both `Y` and `X`
+//' matrices in place.
+//'
+//' @param Y Numeric matrix of data (time x voxels)
+//' @param X Numeric matrix of design (time x predictors)
+//' @param phi_coeffs Numeric vector of AR coefficients (length p)
+//' @param exact_first_ar1 Logical, apply exact scaling of first sample for AR(1)
+//'
+//' @keywords internal
+// [[Rcpp::export]]
+void ar_whiten_inplace(Rcpp::NumericMatrix Y, Rcpp::NumericMatrix X,
+                       const arma::vec& phi_coeffs, bool exact_first_ar1 = false) {
+    arma::mat Ymat(Y.begin(), Y.nrow(), Y.ncol(), false);
+    arma::mat Xmat(X.begin(), X.nrow(), X.ncol(), false);
+    ar_whiten_matrix(Ymat, phi_coeffs, exact_first_ar1);
+    ar_whiten_matrix(Xmat, phi_coeffs, exact_first_ar1);
+}

--- a/tests/testthat/test_ar_whiten.R
+++ b/tests/testthat/test_ar_whiten.R
@@ -1,0 +1,57 @@
+context("C++ AR whitening")
+
+whiten_R <- function(M, phi, exact_first_ar1 = FALSE) {
+  p <- length(phi)
+  nT <- nrow(M)
+  nC <- ncol(M)
+  res <- M
+  for (c in seq_len(nC)) {
+    prev <- rep(0, p)
+    for (t in seq_len(nT)) {
+      orig <- M[t, c]
+      val <- orig - sum(phi * prev)
+      if (t == 1 && exact_first_ar1 && p == 1) {
+        val <- val * sqrt(1 - phi^2)
+      }
+      if (p > 0) {
+        if (p > 1) prev[p:2] <- prev[(p-1):1]
+        prev[1] <- orig
+      }
+      res[t, c] <- val
+    }
+  }
+  res
+}
+
+test_that("ar_whiten_inplace AR1", {
+  Y <- matrix(1:4, ncol = 1)
+  X <- matrix(4:1, ncol = 1)
+  phi <- 0.5
+  Yref <- whiten_R(Y, phi)
+  Xref <- whiten_R(X, phi)
+  ar_whiten_inplace(Y, X, phi)
+  expect_equal(Y, Yref)
+  expect_equal(X, Xref)
+})
+
+test_that("ar_whiten_inplace AR2", {
+  Y <- matrix(1:6, ncol = 1)
+  X <- matrix(6:1, ncol = 1)
+  phi <- c(0.6, -0.3)
+  Yref <- whiten_R(Y, phi)
+  Xref <- whiten_R(X, phi)
+  ar_whiten_inplace(Y, X, phi)
+  expect_equal(Y, Yref)
+  expect_equal(X, Xref)
+})
+
+test_that("ar_whiten_inplace exact first AR1", {
+  Y <- matrix(rnorm(5), ncol = 1)
+  X <- matrix(rnorm(5), ncol = 1)
+  phi <- 0.4
+  Yref <- whiten_R(Y, phi, TRUE)
+  Xref <- whiten_R(X, phi, TRUE)
+  ar_whiten_inplace(Y, X, phi, TRUE)
+  expect_equal(Y, Yref)
+  expect_equal(X, Xref)
+})


### PR DESCRIPTION
## Summary
- add ar_whiten_inplace C++ routine and R wrapper
- register the new C++ symbol
- unit tests for AR(1)/AR(2) whitening and exact-first option

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*