### PR TITLE
Implement cor_global logic

### DIFF
--- a/tests/testthat/test_runwise_ar_fit.R
+++ b/tests/testthat/test_runwise_ar_fit.R
@@ -14,3 +14,12 @@ test_that("fmri_lm runwise AR1 fits without error", {
     NA
   )
 })
+
+test_that("fmri_lm runwise AR1 global fits without error", {
+  expect_error(
+    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+            use_fast_path = TRUE,
+            cor_struct = "ar1", cor_global = TRUE),
+    NA
+  )
+})


### PR DESCRIPTION
## Summary
- add `phi_fixed` parameter to `runwise_lm` and `chunkwise_lm`
- compute global AR coefficients in `fmri_lm_fit` when `cor_global=TRUE`
- use global coefficients when whitening data
- test running `fmri_lm` with global AR settings

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*