### PR TITLE
Implement Ticket 9: document AR prewhitening

### DIFF
--- a/man/fmri_lm.Rd
+++ b/man/fmri_lm.Rd
@@ -16,6 +16,11 @@ fmri_lm(
   nchunks = 10,
   use_fast_path = FALSE,
   progress = FALSE,
+  cor_struct = c("iid", "ar1", "ar2", "arp"),
+  cor_iter = 1L,
+  cor_global = FALSE,
+  ar_p = NULL,
+  ar1_exact_first = FALSE,
   ...
 )
 }
@@ -41,6 +46,16 @@ fmri_lm(
 \item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.}
 
 \item{progress}{Logical. Whether to display a progress bar during model fitting. Default is \code{FALSE}.}
+
+\item{cor_struct}{Error correlation structure. One of \code{"iid"}, \code{"ar1"}, \code{"ar2"}, or \code{"arp"}. The \code{"arp"} option models an AR process of order \code{ar_p}. Only AR terms are currently supported.}
+
+\item{cor_iter}{Number of GLS iterations for AR prewhitening.}
+
+\item{cor_global}{Logical. If \code{TRUE}, AR coefficients are estimated from all runs and applied globally.}
+
+\item{ar_p}{Integer order used when \code{cor_struct = "arp"}.}
+
+\item{ar1_exact_first}{Logical. Apply exact AR(1) scaling to the first sample when \code{cor_struct = "ar1"}.}
 
 \item{...}{Additional arguments.}
 }

--- a/vignettes/a_09_linear_model.Rmd
+++ b/vignettes/a_09_linear_model.Rmd
@@ -219,6 +219,33 @@ model <- fmri_lm(
 model
 ```
 
+### Accounting for Temporal Autocorrelation
+
+The simulated noise contains AR(1) structure. We can ask `fmri_lm` to apply a
+fast AR(1) prewhitening step by setting `cor_struct = "ar1"`. This estimates the
+AR coefficient from an initial OLS fit, whitens the data and design matrix, and
+refits the GLM.
+
+```{r, message=FALSE}
+model_ar1 <- fmri_lm(
+  formula = onset ~ hrf(condition),
+  block   = ~ run,
+  dataset = dataset,
+  strategy = "chunkwise",
+  nchunks = 1,
+  cor_struct = "ar1",
+  cor_iter = 1
+)
+
+# Compare standard errors (first few voxels)
+se_ols <- standard_error(model)
+se_ar1 <- standard_error(model_ar1)
+head(cbind(OLS = se_ols[[1]], AR1 = se_ar1[[1]]))
+```
+
+The `cor_struct` argument also accepts `"arp"` for higher-order autoregressive
+models. This setting models AR coefficients only (no moving-average terms).
+
 
 
 ## Extracting Model Results


### PR DESCRIPTION
## Summary
- expand `fmri_lm` docs to describe AR(p) prewhitening and new arguments
- update man page accordingly
- demonstrate AR(1) correction in linear model vignette

## Testing
- `R` not available so documentation could not be rebuilt or tests run