### PR TITLE
Implement RR.7 robust docs

### DIFF
--- a/man/fmri_lm.Rd
+++ b/man/fmri_lm.Rd
@@ -12,6 +12,11 @@ fmri_lm(
   durations = 0,
   drop_empty = TRUE,
   robust = FALSE,
+  robust_psi = c("huber", "bisquare"),
+  robust_k_huber = 1.345,
+  robust_c_tukey = 4.685,
+  robust_max_iter = 2L,
+  robust_scale_scope = c("run", "global"),
   strategy = c("runwise", "chunkwise"),
   nchunks = 10,
   use_fast_path = FALSE,
@@ -38,6 +43,11 @@ fmri_lm(
 \item{drop_empty}{Logical. Whether to remove factor levels with zero size. Default is \code{TRUE}.}
 
 \item{robust}{Logical. Whether to use robust fitting. Default is \code{FALSE}.}
+\item{robust_psi}{Psi-function for computing weights when \code{robust = TRUE}. Either \code{"huber"} or \code{"bisquare"}.}
+\item{robust_k_huber}{Tuning constant \code{k} for the Huber psi-function.}
+\item{robust_c_tukey}{Tuning constant \code{c} for the Tukey bisquare psi-function.}
+\item{robust_max_iter}{Maximum number of IRLS iterations.}
+\item{robust_scale_scope}{Scope for estimating the robust scale: \code{"run"} or \code{"global"}.}
 
 \item{strategy}{The data splitting strategy, either \code{"runwise"} or \code{"chunkwise"}. Default is \code{"runwise"}.}
 
@@ -65,7 +75,7 @@ A fitted linear regression model for fMRI data analysis.
 \description{
 This function fits a linear regression model for fMRI data analysis using the specified model formula,
 block structure, and dataset. The model can be fit using either a runwise or chunkwise data splitting strategy,
-and robust fitting can be enabled if desired.
+and an optional row-wise robust fitting procedure can be enabled. When \code{robust = TRUE}, time points with large residuals are down-weighted via an Iteratively Reweighted Least Squares approach. Standard errors are based on a final robust scale estimate and p-values should be interpreted with caution.
 }
 \examples{
 

--- a/man/fmri_lm_fit.Rd
+++ b/man/fmri_lm_fit.Rd
@@ -9,6 +9,11 @@ fmri_lm_fit(
   dataset,
   strategy = c("runwise", "chunkwise"),
   robust = FALSE,
+  robust_psi = c("huber", "bisquare"),
+  robust_k_huber = 1.345,
+  robust_c_tukey = 4.685,
+  robust_max_iter = 2L,
+  robust_scale_scope = c("run", "global"),
   nchunks = 10,
   use_fast_path = FALSE,
   progress = FALSE,
@@ -24,6 +29,11 @@ fmri_lm_fit(
 
 \item{robust}{Logical. Whether to use robust fitting. Default is \code{FALSE}.}
 
+\item{robust_psi}{Psi-function for row-wise weights when robust fitting is enabled. Either \code{"huber"} or \code{"bisquare"}.}
+\item{robust_k_huber}{Tuning constant \code{k} for Huber weighting.}
+\item{robust_c_tukey}{Tuning constant \code{c} for Tukey bisquare weighting.}
+\item{robust_max_iter}{Maximum number of IRLS iterations.}
+\item{robust_scale_scope}{Scope for robust scale estimation, \code{"run"} or \code{"global"}.}
 \item{nchunks}{Number of data chunks when strategy is \code{"chunkwise"}. Default is \code{10}.}
 
 \item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.}
@@ -37,8 +47,7 @@ A fitted fMRI linear regression model with the specified fitting strategy.
 }
 \description{
 This function fits an fMRI linear regression model using the specified \code{fmri_model} object, dataset,
-and data splitting strategy (either \code{"runwise"} or \code{"chunkwise"}). It is primarily an internal function
-used by the \code{fmri_lm} function.
+and data splitting strategy (either \code{"runwise"} or \code{"chunkwise"}). When \code{robust = TRUE}, row-wise weights are computed in an Iteratively Reweighted Least Squares loop to down-weight frames with large residuals. Standard errors are based on a robust scale estimate, so resulting p-values are approximate. This function is primarily an internal worker used by \code{fmri_lm}.
 }
 \seealso{
 \code{\link{fmri_lm}}, \code{\link{fmri_model}}, \code{\link{fmri_dataset}}

--- a/vignettes/Overview.Rmd
+++ b/vignettes/Overview.Rmd
@@ -115,9 +115,15 @@ full_model <- fmri_model(event_mod, base_mod)
 # (Requires 'my_dataset' of class fmri_dataset)
 fit <- fmri_lm(full_model, dataset = my_dataset)
 
+# Robust fit down-weighting outlier time points
+fit_robust <- fmri_lm(full_model, dataset = my_dataset, robust = TRUE)
+
 # Extract contrast results
-con_table <- contrast_stats(fit, "FvS") 
+con_table <- contrast_stats(fit, "FvS")
 ```
+
+Setting `robust = TRUE` invokes row-wise weighting to lessen the influence of
+motion spikes or other frame-level artifacts.
 
 *   **See Vignettes:**
     *   `vignette("a_09_linear_model", package = "fmrireg")`

--- a/vignettes/a_09_linear_model.Rmd
+++ b/vignettes/a_09_linear_model.Rmd
@@ -246,6 +246,31 @@ head(cbind(OLS = se_ols[[1]], AR1 = se_ar1[[1]]))
 The `cor_struct` argument also accepts `"arp"` for higher-order autoregressive
 models. This setting models AR coefficients only (no moving-average terms).
 
+### Handling Outliers with Row-Wise Robust Fitting
+
+Real fMRI runs sometimes contain entire time points corrupted by motion or scanner artifacts. The `fmri_lm`
+function can mitigate their impact by enabling row-wise robust weighting. When `robust = TRUE`, an
+Iteratively Reweighted Least Squares loop down-weights frames with large residuals. The `robust_psi`
+argument selects the weighting function and `robust_max_iter` controls the number of iterations.
+
+```{r, message=FALSE}
+model_robust <- fmri_lm(
+  formula = onset ~ hrf(condition),
+  block   = ~ run,
+  dataset = dataset,
+  strategy = "chunkwise",
+  nchunks = 1,
+  robust = TRUE,
+  robust_psi = "huber",
+  robust_max_iter = 2
+)
+
+se_robust <- standard_error(model_robust)
+head(cbind(OLS = se_ols[[1]], Robust = se_robust[[1]]))
+```
+
+Robust fitting guards against outlier time points but will not correct voxel-specific spikes. P-values rely on a robust residual scale and should be interpreted as approximate.
+
 
 
 ## Extracting Model Results


### PR DESCRIPTION
## Summary
- document new robust GLM arguments in `fmri_lm` man files
- describe robust estimation in the function documentation
- add robust fitting example to the linear model vignette
- mention robust option in the overview vignette

## Testing
- `R` was not available so unit tests could not be run