### PR TITLE
Implement SPRINT4-05R voxelwise robust AR

### DIFF
--- a/tests/testthat/test_voxelwise_ar_robust.R
+++ b/tests/testthat/test_voxelwise_ar_robust.R
@@ -1,0 +1,25 @@
+context("voxelwise AR+robust")
+
+options(mc.cores=1)
+
+etab <- data.frame(onset = c(1,10), repnum = factor(c("A","B")), run = c(1,1))
+Y <- matrix(rnorm(20*4), 20, 4)
+dset <- matrix_dataset(Y, TR=1, run_length=20, event_table=etab)
+
+con <- contrast_set(pair_contrast(~ repnum == "A", ~ repnum == "B", name="AvB"))
+
+rob_opts <- list(type = "huber", max_iter = 3)
+
+# Simple check that model runs and produces expected dimensions
+
+test_that("fmri_lm voxelwise AR1 robust fits", {
+  mod <- fmri_lm(onset ~ hrf(repnum, contrasts = con), block = ~ run,
+                 dataset = dset, use_fast_path = FALSE,
+                 ar_voxelwise = TRUE,
+                 cor_struct = "ar1",
+                 robust = "huber",
+                 robust_options = rob_opts)
+  expect_equal(dim(coef(mod)), c(2, 4))
+  ctab <- stats(mod, "contrasts")
+  expect_equal(ncol(ctab), 1)
+})


### PR DESCRIPTION
## Notes
- Added robust fitting support for voxelwise AR contrasts using the chunked engine.
- New test ensures voxelwise AR1 model works with robust weighting.

## Summary
- expanded `store_voxel_contrasts` to accept precomputed `XtXinv` and robust weights
- enhanced `fit_lm_contrasts_voxelwise_chunked` with `robust_options` and IRLS fitting
- added `test_voxelwise_ar_robust.R` for voxelwise AR+robust path
