### PR TITLE
Update robust option names in tests and code

### DIFF
--- a/R/fmri_lm_methods.R
+++ b/R/fmri_lm_methods.R
@@ -320,7 +320,7 @@ print.fmri_lm <- function(x, ...) {
     # Robust info
     if (cfg$robust$type != FALSE) {
       cli::cli_li("Robust method: {.field {cfg$robust$type}}")
-      cli::cli_li("Robust tuning: {.val {cfg$robust$tuning}}")
+      cli::cli_li("Robust tuning: {.val {cfg$robust$c_tukey}}")
     }
     cli::cli_end()
   }

--- a/R/sandwich_variance_doc.R
+++ b/R/sandwich_variance_doc.R
@@ -40,7 +40,7 @@
 #' cfg <- fmri_lm_control(
 #'   robust = list(
 #'     type = "bisquare",
-#'     tuning = 4.685
+#'     c_tukey = 4.685
 #'   )
 #' )
 #' 

--- a/tests/testthat/test_ar_robust_combined.R
+++ b/tests/testthat/test_ar_robust_combined.R
@@ -49,7 +49,7 @@ test_that("AR + Robust combination works in runwise", {
     block = ~ run,
     dataset = dset,
     strategy = "runwise",
-    robust_options = list(type = "bisquare", tuning = 4.685),
+    robust_options = list(type = "bisquare", c_tukey = 4.685),
     ar_options = list(struct = "ar1", iter_gls = 1),
     use_fast_path = TRUE
   )

--- a/tests/testthat/test_fmri_lm_config.R
+++ b/tests/testthat/test_fmri_lm_config.R
@@ -11,12 +11,12 @@ test_that("fmri_lm_control creates valid config objects", {
   cfg2 <- fmri_lm_control(
     robust_options = list(
       type = "bisquare",
-      tuning = 4.685,
+      c_tukey = 4.685,
       max_iter = 20
     )
   )
   expect_equal(cfg2$robust$type, "bisquare")
-  expect_equal(cfg2$robust$tuning, 4.685)
+  expect_equal(cfg2$robust$c_tukey, 4.685)
   expect_equal(cfg2$robust$max_iter, 20)
   
   # AR config
@@ -55,10 +55,10 @@ test_that("fmri_lm_control validates inputs", {
     "should be one of"
   )
   
-  # Invalid tuning parameter - currently not validated
+  # Invalid c_tukey parameter - currently not validated
   # expect_error(
-  #   fmri_lm_control(robust_options = list(type = "bisquare", tuning = -1)),
-  #   "tuning"
+  #   fmri_lm_control(robust_options = list(type = "bisquare", c_tukey = -1)),
+  #   "c_tukey"
   # )
   
   # Missing ar_p for arp - currently uses default


### PR DESCRIPTION
## Summary
- update `bisquare` tuning option to use `c_tukey`
- reflect new option names in config tests
- print `c_tukey` in model summary
- update documentation example

## Testing
- `devtools::test()` *(fails: `R` command not found)*