### PR TITLE
Implement feature suffix naming for event matrices

### DIFF
--- a/R/event-classes.R
+++ b/R/event-classes.R
@@ -164,9 +164,10 @@ event <- function(value, name, onsets, blockids, durations = 0, subset = NULL) {
 #'   provided, the vector must match `onsets` in length and contain no `NA`
 #'   values.
 #'
-#' If `mat` has column names and more than one column, those names are
-#' sanitized using `.sanitizeName()` before being stored. The sanitized
-#' column names are returned by `levels()` for the resulting event object.
+#' Column names are sanitized using `.sanitizeName()` if provided. If
+#' column names are missing or not unique, deterministic feature suffixes
+#' (`f01`, `f02`, ...) are generated instead. The resulting names are
+#' returned by `levels()` for the event object.
 #'
 #' @return An S3 object of class `event` and `event_seq`.
 #'
@@ -271,9 +272,12 @@ event_matrix <- function(mat, name, onsets, blockids = 1, durations = 0, subset 
   assert_that(nrow(mat) == length(onsets),
               msg = sprintf("Length mismatch for '%s': nrow(mat)=%d, length(onsets)=%d",
                           name, nrow(mat), length(onsets)))
-  # Sanitize column names when multiple columns are provided
-  if (ncol(mat) > 1 && !is.null(colnames(mat))) {
-      colnames(mat) <- .sanitizeName(colnames(mat))
+  # Ensure deterministic column names
+  cn <- colnames(mat)
+  if (is.null(cn) || anyDuplicated(cn)) {
+      colnames(mat) <- feature_suffix(seq_len(ncol(mat)), ncol(mat))
+  } else {
+      colnames(mat) <- .sanitizeName(cn)
   }
   
   # Call the unified internal constructor

--- a/R/naming-utils.R
+++ b/R/naming-utils.R
@@ -57,6 +57,20 @@ basis_suffix <- function(j, nb) {
   paste0("_b", zeropad(j, nb))
 }
 
+#' Create Feature Suffix
+#'
+#' Generates the `_f##` suffix for multi-column continuous events.
+#'
+#' @param j Integer vector of feature indices (1-based).
+#' @param nf Total number of features.
+#' @return Character vector of suffixes (e.g., `_f01`, `_f02`).
+#' @export
+#' @examples
+#' feature_suffix(1:3, 5)
+feature_suffix <- function(j, nf) {
+  paste0("_f", zeropad(j, nf))
+}
+
 #' Make Tags Unique with Hash Separator
 #'
 #' Wraps `make.unique` using `#` as the separator.

--- a/R/utils-internal.R
+++ b/R/utils-internal.R
@@ -101,8 +101,8 @@ recycle_or_error <- function(x, target, label) {
     # Categorical: Use actual levels
     vapply(lvls, \(l) .label_component(ev, l), character(1))
   } else if (is_continuous(ev) && length(lvls) > 1) {
-    # Continuous multi-column (matrix/basis): Use index 1:ncol
-    vapply(seq_along(lvls), \(k) .label_component(ev, k), character(1))
+    # Continuous multi-column (matrix/basis): Use feature names
+    vapply(lvls, \(l) .label_component(ev, l), character(1))
   } else if (is_continuous(ev) && length(lvls) == 1) {
     # Single continuous variable (vector): Just the variable name
     .label_component(ev) # level = NULL implicit

--- a/man/event_matrix.Rd
+++ b/man/event_matrix.Rd
@@ -21,9 +21,10 @@ event_matrix(mat, name, onsets, blockids = 1, durations = 0, subset = NULL)
 provided, the vector must match \code{onsets} in length and contain no \code{NA}
 values.
 
-If \code{mat} has column names and more than one column, those names are
-sanitized using \code{.sanitizeName()} before being stored. The sanitized
-column names are returned by \code{levels()} for the resulting event object.}
+Column names are sanitized using \code{.sanitizeName()} when provided. If
+column names are missing or not unique, deterministic feature suffixes
+(\verb{f01}, \verb{f02}, ...) are generated instead. These names are
+returned by \code{levels()} for the resulting event object.}
 }
 \value{
 An S3 object of class \code{event} and \code{event_seq}.

--- a/tests/testthat/test_event_vector.R
+++ b/tests/testthat/test_event_vector.R
@@ -108,6 +108,21 @@ test_that("event_matrix sanitizes colnames when necessary", {
   expect_equal(levels(ev), .sanitizeName(c("A B", "C-D")), ignore_attr = TRUE)
 })
 
+test_that("event_matrix assigns feature suffix names when colnames missing", {
+  mat <- matrix(seq_len(6), ncol = 2)
+  onsets <- 1:3
+  ev <- event_matrix(mat, "m", onsets, rep(1, 3))
+  expect_equal(levels(ev), c("f01", "f02"), ignore_attr = TRUE)
+})
+
+test_that("event_matrix assigns feature suffix names when colnames duplicated", {
+  mat <- matrix(seq_len(6), ncol = 2)
+  colnames(mat) <- c("dup", "dup")
+  onsets <- 1:3
+  ev <- event_matrix(mat, "m", onsets, rep(1, 3))
+  expect_equal(levels(ev), c("f01", "f02"), ignore_attr = TRUE)
+})
+
 # Add test for event_basis wrapper
 test_that("event_basis wrapper works and creates correct event object", {
   skip_if_not_installed("splines")
@@ -149,6 +164,20 @@ test_that("BSpline constructor respects degree argument", {
   b <- BSpline(x, degree = deg)
   expect_equal(ncol(b$y), deg)
   expect_equal(nbasis(b), deg)
+})
+
+test_that("feature and basis suffixes combine in convolve", {
+  mat <- matrix(seq_len(6), ncol = 2)
+  onsets <- 1:3
+  ev <- event_matrix(mat, "m", onsets, rep(1, 3))
+  term <- event_term(list(m = ev), onsets, blockids = rep(1, 3))
+  attr(term, "term_tag") <- "term"
+  sf <- sampling_frame(blocklens = 10, TR = 1)
+  cmat <- convolve(term, hrf = HRF_SPMG3, sampling_frame = sf)
+  expect_equal(colnames(cmat),
+               c("term_f01_b01", "term_f02_b01",
+                 "term_f01_b02", "term_f02_b02",
+                 "term_f01_b03", "term_f02_b03"))
 })
 
 # ==================================


### PR DESCRIPTION
## Summary
- add `feature_suffix()` helper
- assign deterministic feature suffixes in `event_matrix()` when names absent or duplicated
- use feature names in `.level_vector()`
- document column name behaviour for `event_matrix`
- add tests for feature suffix naming and HRF basis naming

## Testing
- `devtools::test()` *(fails: R not available)*