### PR TITLE
Fix QR contrast variance calc

### DIFF
--- a/R/fmri_lm_internal.R
+++ b/R/fmri_lm_internal.R
@@ -476,8 +476,8 @@ fit_lm_contrasts_voxelwise_qr <- function(Betas, qr_list, sigma,
       qr_v <- qr_list[[v]]
       rw <- if (!is.null(robust_weights_list)) robust_weights_list[[v]] else NULL
 
-      Qtl <- qr.qty(qr_v, full_l)
-      var_con <- sum(Qtl[1:qr_v$rank]^2) * sigma[v]^2
+      Rinvl <- backsolve(qr.R(qr_v), full_l, upper.tri = TRUE)
+      var_con <- sum(Rinvl^2) * sigma[v]^2
 
       est[v] <- sum(full_l * Betas[, v])
       se[v]  <- sqrt(var_con)


### PR DESCRIPTION
## Summary
- fix QR-based contrast variance computation

## Testing
- `R CMD build .` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68457ff76754832d92826491f0e99b87