### PR TITLE
Allow dataframe nuisance regressors

### DIFF
--- a/R/baseline_model.R
+++ b/R/baseline_model.R
@@ -62,7 +62,7 @@ get_col_inds <- function(mat_list) {
 
 #' Build a baseline_term from a list of block‑wise nuisance matrices
 #'
-#' @param nuisance_list list of numeric matrices, **one per run/block**.
+#' @param nuisance_list list of numeric matrices or data frames, **one per run/block**.
 #' @param sframe        the sampling_frame used in the model.
 #' @param prefix        prefix used when auto‑naming the columns.
 #'
@@ -73,7 +73,10 @@ make_nuisance_term <- function(nuisance_list,
                                prefix = "nuis") {
 
   stopifnot(is.list(nuisance_list),
-            all(vapply(nuisance_list, is.matrix, logical(1))))
+            all(vapply(nuisance_list,
+                        function(x) is.matrix(x) || is.data.frame(x),
+                        logical(1))))
+  nuisance_list <- lapply(nuisance_list, as.matrix)
   nb      <- length(fmrihrf::blocklens(sframe))
   bl_lens <- fmrihrf::blocklens(sframe)
 
@@ -87,7 +90,7 @@ make_nuisance_term <- function(nuisance_list,
     stop("Each nuisance matrix must have nrow == block length for its block.")
 
   ## --- assemble block‑diagonal matrix ------------------------------------
-  full_mat <- as.matrix(Matrix::bdiag(lapply(nuisance_list, unclass)))
+  full_mat <- as.matrix(Matrix::bdiag(nuisance_list))
   ncols    <- ncol(full_mat)
 
   ## names:  prefix#<block>_<col>
@@ -119,7 +122,7 @@ make_nuisance_term <- function(nuisance_list,
 #' @param intercept Character; whether to include an intercept ("runwise", "global", or "none").
 #'   Ignored when \code{basis == "constant"} because the drift term already
 #'   provides the constant baseline.
-#' @param nuisance_list Optional list of nuisance matrices (one matrix per fMRI block).
+#' @param nuisance_list Optional list of nuisance matrices or data frames (one per fMRI block).
 #'
 #' @return An object of class "baseline_model".
 #'

--- a/man/baseline_model.Rd
+++ b/man/baseline_model.Rd
@@ -23,7 +23,7 @@ baseline_model(
 Ignored when \code{basis == "constant"} because the drift term already
 provides the constant baseline.}
 
-\item{nuisance_list}{Optional list of nuisance matrices (one matrix per fMRI block).}
+\item{nuisance_list}{Optional list of nuisance matrices or data frames (one per fMRI block).}
 }
 \value{
 An object of class "baseline_model".

--- a/tests/testthat/test_baseline.R
+++ b/tests/testthat/test_baseline.R
@@ -63,6 +63,19 @@ test_that("can construct a baseline_model with 2 blocks and nuisance_list", {
   expect_true(setequal(names(terms(bmodel)), c("block", "drift", "nuisance")))
 })
 
+test_that("baseline_model accepts data.frame nuisance_list", {
+  sframe <- fmrihrf::sampling_frame(blocklens = 100, TR = 2)
+  nlist <- list(
+    tibble::tibble(a = rnorm(100), b = rnorm(100))
+  )
+
+  bmodel <- baseline_model(basis = "bs", degree = 5,
+                           sframe = sframe, nuisance_list = nlist)
+
+  expect_equal(ncol(design_matrix(bmodel)), 9)
+  expect_true("nuisance" %in% names(terms(bmodel)))
+})
+
 test_that("can construct a baseline_model with basis='constant'", {
   sframe <- fmrihrf::sampling_frame(blocklens=c(100,100), TR=2)
   # Intercept option should be ignored/overridden when basis is constant


### PR DESCRIPTION
## Summary
- relax `make_nuisance_term()` validation to accept data frames
- convert nuisance entries to matrices and build block-diagonal matrix
- document that `nuisance_list` may contain data frames
- test baseline_model with data.frame nuisance list

## Testing
- `devtools::document()` *(fails: R not installed)*
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68517560a9b8832d8c915b095c532459