### PR TITLE
Support subset mapping for contrasts

### DIFF
--- a/man/Fcontrasts.Rd
+++ b/man/Fcontrasts.Rd
@@ -68,6 +68,8 @@ Create F-contrasts to test for overall effects of model terms. F-contrasts are u
 \item{nonlinear}{Test for nonlinear effects of continuous predictors}
 \item{overall}{Evaluate overall significance of model terms}
 }
+Row names on the contrast matrices can be matched to specific term columns,
+allowing tests on subsets of levels.
 }
 \examples{
 # Create a sampling frame with multiple runs

--- a/man/contrast_weights.Rd
+++ b/man/contrast_weights.Rd
@@ -35,6 +35,9 @@ This function calculates the contrast weights based on the contrast specificatio
 provided by the user. It is a generic function that dispatches to the appropriate
 method depending on the class of the contrast specification (e.g., unit_contrast_spec,
 pair_contrast_spec, poly_contrast_spec, etc.).
+When row names are provided on the weight matrix, they are matched against
+the corresponding term column names allowing contrasts to target a subset of
+term levels.
 }
 \examples{
 # Create a data frame with experimental design


### PR DESCRIPTION
## Summary
- allow contrast rows to map by name to subsets of term columns in `contrast_weights.event_model`
- apply same logic for F-contrasts
- document that contrasts can span subsets of term levels

## Testing
- `devtools::test()` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517901bcc0832d907775308b150793