### PR TITLE
Fix naming utils for numeric level tokens

### DIFF
--- a/R/naming-utils.R
+++ b/R/naming-utils.R
@@ -42,6 +42,23 @@ sanitize <- function(x, allow_dot = TRUE) {
   sanitized
 }
 
+#' Sanitize Factor Level
+#'
+#' Similar to `sanitize()` but if the original level begins with a digit,
+#' remove the leading `"X"` that `make.names` would prepend.
+#'
+#' @param lev A factor level string.
+#' @return Sanitized level string.
+#' @keywords internal
+#' @noRd
+sanitize_level <- function(lev) {
+  sanitized <- sanitize(lev, allow_dot = TRUE)
+  if (grepl("^[0-9]", lev) && startsWith(sanitized, "X")) {
+    sanitized <- sub("^X", "", sanitized)
+  }
+  sanitized
+}
+
 #' Create Basis Function Suffix
 #'
 #' Generates the `_b##` suffix for HRF basis functions.
@@ -167,9 +184,9 @@ make_term_tag <- function(hrfspec, existing_tags = character()) {
 #' @keywords internal
 #' @noRd
 level_token <- function(var, lev) {
-  # Sanitize both parts, allowing dots
+  # Sanitize variable and level parts
   s_var <- sanitize(var, allow_dot = TRUE)
-  s_lev <- sanitize(lev, allow_dot = TRUE)
+  s_lev <- sanitize_level(lev)
   paste0(s_var, ".", s_lev)
 }
 

--- a/tests/testthat/test-naming-utils.R
+++ b/tests/testthat/test-naming-utils.R
@@ -52,6 +52,7 @@ test_that("make_term_tag generates tags", {
 test_that("level_token creates Var.Level format", {
   expect_equal(fmrireg:::level_token("cond", "A"), "cond.A")
   expect_equal(fmrireg:::level_token("cond name", "Level 1"), "cond.name.Level.1")
+  expect_equal(fmrireg:::level_token("Input", "20"), "Input.20")
 })
 
 test_that("continuous_token sanitizes", {


### PR DESCRIPTION
## Summary
- add `sanitize_level()` helper to strip `X` from digit-leading levels
- use new helper in `level_token`
- test numeric level handling

## Testing
- `devtools::test()` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685191f2776c832db48e294d3e7d7815