### PR TITLE
Fix contrast filtering in AFNI command builder

### DIFF
--- a/R/afni.R
+++ b/R/afni.R
@@ -524,7 +524,9 @@ build_decon_command <- function(model, dataset, working_dir, opts) {
   
   ## extract all contrast matrices
   cons <- contrast_weights(model)
-  cons <- unlist(cons, recursive=FALSE)
+  ## ensure contrasts are valid objects
+  cons <- Filter(function(x) inherits(x, "contrast"), cons)
+  assert_that(is.list(cons), all(sapply(cons, inherits, "contrast")))
   
   ## convert to 'glt's
   glts <- lapply(cons, to_glt)


### PR DESCRIPTION
## Summary
- ensure AFNI deconvolution only handles valid `contrast` objects
- add assertions to verify list of contrasts

## Testing
- `R -q -e "testthat::test_file('tests/testthat/test_afni_hrf.R')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685420c0c904832da525591416e6ccc0