### PR TITLE
Fix design matrix inversion failure

### DIFF
--- a/R/fmri_lm_chunkwise.R
+++ b/R/fmri_lm_chunkwise.R
@@ -52,8 +52,8 @@ chunkwise_lm.fmri_dataset <- function(dset, model, contrast_objects, nchunks, cf
   data_env <- list2env(tmats)
   data_env[[".y"]] <- rep(0, nrow(tmats[[1]]))
   modmat <- model.matrix(as.formula(form), data_env)
-  Qr_global <- qr(modmat)
-  Vu <- chol2inv(Qr_global$qr)
+  proj_global <- .fast_preproject(modmat)
+  Vu <- proj_global$XtXinv
   
   # Process chunks
   if (use_fast_path) {

--- a/R/fmri_lm_runwise.R
+++ b/R/fmri_lm_runwise.R
@@ -50,8 +50,8 @@ runwise_lm <- function(dset, model, contrast_objects, cfg, verbose = FALSE,
   
   # Global design matrix for Vu calculation
   modmat_global <- design_matrix(model)
-  Qr_global <- qr(modmat_global)
-  Vu <- chol2inv(Qr_global$qr)
+  proj_global <- .fast_preproject(modmat_global)
+  Vu <- proj_global$XtXinv
   
   # Separate contrast types
   simple_conlist <- Filter(function(x) inherits(x, "contrast"), contrast_objects)

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -1193,8 +1193,8 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
       data_env <- list2env(tmats)
       data_env[[ ".y"]] <- rep(0, nrow(tmats[[1]])) # Corrected [[ ]] indexing
       modmat <- model.matrix(as.formula(form), data_env)
-      Qr_global <- qr(modmat)
-      Vu <- chol2inv(Qr_global$qr)
+      proj_global <- .fast_preproject(modmat)
+      Vu <- proj_global$XtXinv
       
       lmfun <- if (cfg$robust$type != FALSE) multiresponse_rlm else multiresponse_lm
       
@@ -1380,7 +1380,7 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
           
           proj_global_final_w <- .fast_preproject(X_global_final_w)
           
-          Vu <- chol2inv(qr(design_matrix(model))$qr)
+          Vu <- .fast_preproject(design_matrix(model))$XtXinv
           nvox <- ncol(dset$datamat)
 
           cres <- vector("list", length(run_chunks))
@@ -1625,8 +1625,8 @@ runwise_lm <- function(dset, model, contrast_objects, cfg, verbose = FALSE,
   form <- get_formula(model)
   # Global design matrix needed for pooling compatibility? Or just for Vu?
   modmat_global <- design_matrix(model)
-  Qr_global <- qr(modmat_global)
-  Vu <- chol2inv(Qr_global$qr)
+  proj_global <- .fast_preproject(modmat_global)
+  Vu <- proj_global$XtXinv
   
   # Define ym for R CMD check
   ym <- NULL


### PR DESCRIPTION
## Summary
- avoid `chol2inv` on rank-deficient design matrices when fitting models
- compute `(X'X)^{-1}` via `.fast_preproject()` in runwise and chunkwise code paths

## Testing
- `devtools::test()` *(fails: `R` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68558e5a7794832dba2b9a9eb8eba672