### PR TITLE
Fix multiple bugs: division by zero, undefined variable, edge cases

### DIFF
--- a/R/all_generic.R
+++ b/R/all_generic.R
@@ -10,23 +10,14 @@ with_package <- function(name) {
 
 
 
-# event_model generic is now imported from fmridesign
+# NOTE: Many generics are imported from specialized packages:
+# - fmridesign: event_model, term_matrices, contrast_weights, cells, conditions,
+#               convolve, is_continuous, is_categorical, event_table, event_terms,
+#               baseline_terms, term_indices, design_matrix, elements, onsets,
+#               durations, split_by_block, Fcontrasts, split_onsets
+# - fmridataset: get_data, get_data_matrix, get_mask, data_chunks
+# - fmrihrf: evaluate, global_onsets, nbasis, samples, blockids, blocklens
 # See fmridesign-imports.R for re-exports
-
-
-
-#' get_data
-#' 
-#' @param x the dataset
-#' @param ... extra args
-#' @keywords internal
-# get_data <- function(x, ...) UseMethod("get_data") # Now imported from fmridataset
-
-
-# get_data_matrix <- function(x, ...) UseMethod("get_data_matrix") # Now imported from fmridataset
-
-
-# get_mask <- function(x, ...) UseMethod("get_mask") # Now imported from fmridataset
 
 
 #' Retrieve the formula underlying a model object
@@ -38,11 +29,6 @@ with_package <- function(name) {
 #' @return A formula.
 #' @export
 get_formula <- function(x, ...) UseMethod("get_formula")
-
-
-# term_matrices generic is now imported from fmridesign
-# term_matrices <- function(x, ...) UseMethod("term_matrices")
-
 
 
 #' design_env
@@ -125,11 +111,6 @@ tidy <- function(x, ...) UseMethod("tidy")
 #'   name = "A_vs_B"
 #' )
 #' 
-# contrast_weights generic is now imported from fmridesign
-# See fmridesign-imports.R for re-exports
-
-
-
 
 
 #' The experimental cells of a design
@@ -183,11 +164,6 @@ tidy <- function(x, ...) UseMethod("tidy")
 #' @export
 #' @family cells
 #' @seealso [event_term()], [event_model()]
-# cells generic is now imported from fmridesign
-# cells <- function(x, ...) UseMethod("cells")
-
-
-
 #' Conditions
 #' 
 #' Return the set of condition labels associated with a model term. Conditions represent 
@@ -236,11 +212,6 @@ tidy <- function(x, ...) UseMethod("tidy")
 #' @export
 #' @family conditions
 #' @seealso [cells()], [event_model()], [hrf()]
-# conditions generic is now imported from fmridesign
-# conditions <- function(x, ...) UseMethod("conditions")
-
-
-
 #' Convolve a term with a hemodynamic response function
 #'
 #' @description
@@ -288,18 +259,6 @@ tidy <- function(x, ...) UseMethod("tidy")
 #' @export
 #' @family convolution
 #' @seealso [HRF_SPMG1()], [event_term()], [sampling_frame()]
-# convolve generic is now imported from fmridesign
-# convolve <- function(x, hrf, sampling_frame, ...) UseMethod("convolve")
-
-
-# is_continuous generic is now imported from fmridesign
-
-
-
-# is_categorical generic is now imported from fmridesign
-
-
-
 #' columns
 #' 
 #' return the column labels associated with the elements of a term.
@@ -347,29 +306,12 @@ columns.event_model <- function(x, ...) {
 
 
 
-# event_table generic is now imported from fmridesign
-
-
-
-# event_terms generic is now imported from fmridesign
-
-
-
-# baseline_terms generic is now imported from fmridesign
-
-
-# term_indices generic is now imported from fmridesign
 # The event_model method was moved to fmridesign
 
 
 
 
 
-# design_matrix generic is now imported from fmridesign
-# design_matrix <- function(x, ...) { UseMethod("design_matrix") }
-
-# elements generic is now imported from fmridesign
-# elements <- function(x, ...) UseMethod("elements")
 
 
 #' correlation_map
@@ -439,11 +381,6 @@ correlation_map <- function(x, ...) {
   UseMethod("correlation_map")
 }
 
-
-
-# evaluate is now imported from fmrihrf
-
-
 #' fitted_hrf
 #'
 #' This generic function computes the fitted hemodynamic response function (HRF) for an object.
@@ -498,36 +435,12 @@ fitted_hrf <- function(x, sample_at, ...) UseMethod("fitted_hrf")
 
 
 
-# global_onsets <- function(x, onsets, ...) UseMethod("global_onsets") # Now imported from fmrihrf
-
-
-
-# nbasis generic is now imported from fmrihrf package
-# See fmrihrf-imports.R for the import statement
 
 
 
 
 
- 
-# data_chunks <- function(x, nchunks, ...) UseMethod("data_chunks") # Now imported from fmridataset
 
-
-# onsets generic is now imported from fmridesign
-# onsets <- function(x) UseMethod("onsets")
-
-
-# durations generic is now imported from fmridesign
-# durations <- function(x) UseMethod("durations")
-
-# samples <- function(x, ...) UseMethod("samples") # Now imported from fmrihrf
-
-# split_by_block generic is now imported from fmridesign
-# split_by_block <- function(x, ...) UseMethod("split_by_block")
-
-# blockids is now imported from fmrihrf
-
-# blocklens is now imported from fmrihrf
 
 #' Generate F-contrasts for a model term
 #' 
@@ -585,8 +498,6 @@ fitted_hrf <- function(x, sample_at, ...) UseMethod("fitted_hrf")
 #'   sampling_frame = sframe
 #' )
 #' 
-# Fcontrasts generic is now imported from fmridesign
-
 #' construct
 #' 
 #' construct a term given a an hrf spec and model specification
@@ -659,8 +570,6 @@ construct <- function(x, model_spec,...) UseMethod("construct")
 #' @family timing_functions
 #' @seealso [event_term()], [sampling_frame()], [global_onsets()]
 #' @export
-# split_onsets is now imported from fmridesign
-
 
 
 #' estimate contrast
@@ -1002,7 +911,6 @@ estimate_betas <- function(x, ...) UseMethod("estimate_betas")
 #'     \item{rotate_x_text}{Logical; if TRUE, rotate x-axis labels by 45 degrees}
 #'   }
 #' @return A ggplot2 object containing the design matrix heatmap
-# design_map generic moved to fmridesign package
 
 
 

--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -89,13 +89,19 @@ multiresponse_bootstrap_lm <- function(form, data_env,
   }
   rows <- 1:nrow(yhat)
   nblocks <- as.integer(length(rows)/block_size)
-  
+
   # Create blocks for resampling
-  blocks <- split(rows, rep(1:nblocks, each=length(rows)/nblocks, length.out=length(rows)))
-  maxind <- max(blocks[[length(blocks)]])
-  if (maxind < nrow(yhat)) {
-    last_block <- (maxind+1):nrow(yhat)
-    blocks <- c(blocks, list(last_block))
+  # Handle edge case when fewer rows than block_size: use single block
+
+  if (nblocks < 1) {
+    blocks <- list(rows)
+  } else {
+    blocks <- split(rows, rep(seq_len(nblocks), each = length(rows) / nblocks, length.out = length(rows)))
+    maxind <- max(blocks[[length(blocks)]])
+    if (maxind < nrow(yhat)) {
+      last_block <- (maxind + 1):nrow(yhat)
+      blocks <- c(blocks, list(last_block))
+    }
   }
   
   # Perform bootstrap

--- a/R/fmri_betas.R
+++ b/R/fmri_betas.R
@@ -18,17 +18,16 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
   }
   
   # Ensure ran_ind has proper values
-  if (length(ran_ind) == 0) {
+  if (is_empty_indices(ran_ind)) {
     stop("No random effect indices specified")
   }
-  
-  # Handle case when fixed_ind is NULL
-  if (is.null(fixed_ind)) {
-    fixed_ind <- integer(0)  # Empty integer vector
-  }
-  
+
+  # Normalize fixed_ind to integer vector
+  fixed_ind <- as_indices(fixed_ind)
+
   # Check if indices are out of bounds
-  if (max(c(ran_ind, fixed_ind)) > ncol(X)) {
+  all_indices <- c(ran_ind, fixed_ind)
+  if (length(all_indices) > 0 && max(all_indices) > ncol(X)) {
     stop("Index out of bounds: indices exceed number of columns in X")
   }
   
@@ -42,7 +41,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
     with_package("rrBLUP")
     
     # If fixed_ind is empty, use a minimal X matrix (intercept only)
-    X_fixed <- if (length(fixed_ind) == 0) {
+    X_fixed <- if (is_empty_indices(fixed_ind)) {
       matrix(1, nrow = nrow(X), ncol = 1)
     } else {
       X[, fixed_ind, drop = FALSE]
@@ -55,7 +54,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
                                #bounds = c(1e-07, 0.5))
     
     # Return results, handling the case where fixed_ind is empty
-    if (length(fixed_ind) == 0) {
+    if (is_empty_indices(fixed_ind)) {
       return(fit$u)  # Only return random effects
     } else {
       return(c(fit$u, fit$b))  # Return both random and fixed effects
@@ -69,7 +68,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
         requireNamespace("fmrilss", quietly = TRUE)) {
       
       # Use the C++ implementation with proper input validation
-      X_fixed <- if (length(fixed_ind) == 0) {
+      X_fixed <- if (is_empty_indices(fixed_ind)) {
         matrix(1, nrow = nrow(X), ncol = 1)
       } else {
         X[, fixed_ind, drop = FALSE]
@@ -83,7 +82,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
         # If even that fails, return NAs with warning
         warning("C++ mixed model solver also failed: ", e2$message,
                 " - returning NA values.")
-        if (length(fixed_ind) == 0) {
+        if (is_empty_indices(fixed_ind)) {
           return(list(u = rep(NA_real_, length(ran_ind))))
         } else {
           return(list(
@@ -94,7 +93,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
       })
       
       # Return results based on whether fixed_ind is empty
-      if (length(fixed_ind) == 0) {
+      if (is_empty_indices(fixed_ind)) {
         return(fit$u)
       } else {
         return(c(fit$u, fit$beta))
@@ -103,7 +102,7 @@ mixed_betas <- function(X, Y, ran_ind, fixed_ind) {
       # Last resort - return NAs with warning since zeros would be misleading
       warning("No alternative mixed model solver available - returning NA values. ",
               "Results for this voxel will be invalid. Consider installing rrBLUP or fmrilss packages.")
-      if (length(fixed_ind) == 0) {
+      if (is_empty_indices(fixed_ind)) {
         return(rep(NA_real_, length(ran_ind)))
       } else {
         return(rep(NA_real_, length(c(ran_ind, fixed_ind))))

--- a/R/fmri_lm_chunkwise.R
+++ b/R/fmri_lm_chunkwise.R
@@ -337,12 +337,7 @@ chunkwise_lm_slow <- function(chunks, model, cfg, contrast_objects,
         sigma_vec <- rep(sigma_vec, ncol(betas))
       }
       dfres <- result$df_residual %||% proj_modmat$dfres
-      ar_order <- result$ar_order %||% switch(cfg$ar$struct,
-        ar1 = 1L,
-        ar2 = 2L,
-        arp = cfg$ar$p,
-        0L
-      )
+      ar_order <- result$ar_order %||% get_ar_order(cfg)
 
       bstats <- beta_stats_matrix(
         betas,

--- a/R/fmri_lm_chunkwise.R
+++ b/R/fmri_lm_chunkwise.R
@@ -165,34 +165,19 @@ chunkwise_lm_fast <- function(dset, chunks, model, cfg, contrast_objects,
         NULL
       }
       
-      # Beta statistics
-      bstats <- beta_stats_matrix(
-        chunk_res$betas,
-        precomp$proj_global$XtXinv,
-        sigma_vec,
-        precomp$proj_global$dfres,
-        actual_vnames,
-        robust_weights = robust_weights_for_stats,
-        ar_order = precomp$ar_order
-      )
-      
-      # Contrast statistics
-      conres <- fit_lm_contrasts_fast(
-        chunk_res$betas,
-        chunk_res$sigma2,
-        precomp$proj_global$XtXinv,
-        simple_conlist_weights,
-        fconlist_weights,
-        precomp$proj_global$dfres,
-        robust_weights = robust_weights_for_stats,
-        ar_order = precomp$ar_order
-      )
-      
-      cres[[i]] <- list(
-        bstats = bstats,
-        contrasts = conres,
+      # Compute chunk statistics using shared helper
+      cres[[i]] <- compute_chunk_stats(
+        betas = chunk_res$betas,
+        sigma2 = chunk_res$sigma2,
+        XtXinv = precomp$proj_global$XtXinv,
+        dfres = precomp$proj_global$dfres,
+        varnames = actual_vnames,
+        simple_conlist_weights = simple_conlist_weights,
+        fconlist_weights = fconlist_weights,
         event_indices = event_indices,
-        baseline_indices = baseline_indices
+        baseline_indices = baseline_indices,
+        robust_weights = robust_weights_for_stats,
+        ar_order = precomp$ar_order
       )
       
       if (progress) cli::cli_progress_update()
@@ -220,38 +205,19 @@ chunkwise_lm_fast <- function(dset, chunks, model, cfg, contrast_objects,
       glm_ctx_chunk <- glm_context(X = modmat, Y = Ymat, proj = proj)
       res <- solve_glm_core(glm_ctx_chunk)
       
-      # Calculate statistics
-      actual_vnames <- colnames(modmat)
-      sigma_vec <- sqrt(res$sigma2)
-      
-      # Beta statistics
-      bstats <- beta_stats_matrix(
-        res$betas,
-        proj$XtXinv,
-        sigma_vec,
-        proj$dfres,
-        actual_vnames,
-        robust_weights = NULL,
-        ar_order = ar_order
-      )
-      
-      # Contrast statistics
-      conres <- fit_lm_contrasts_fast(
-        res$betas,
-        res$sigma2,
-        proj$XtXinv,
-        simple_conlist_weights,
-        fconlist_weights,
-        proj$dfres,
-        robust_weights = NULL,
-        ar_order = ar_order
-      )
-      
-      cres[[i]] <- list(
-        bstats = bstats,
-        contrasts = conres,
+      # Compute chunk statistics using shared helper
+      cres[[i]] <- compute_chunk_stats(
+        betas = res$betas,
+        sigma2 = res$sigma2,
+        XtXinv = proj$XtXinv,
+        dfres = proj$dfres,
+        varnames = colnames(modmat),
+        simple_conlist_weights = simple_conlist_weights,
+        fconlist_weights = fconlist_weights,
         event_indices = event_indices,
-        baseline_indices = baseline_indices
+        baseline_indices = baseline_indices,
+        robust_weights = NULL,
+        ar_order = ar_order
       )
       
       if (progress) cli::cli_progress_update()
@@ -339,30 +305,24 @@ chunkwise_lm_slow <- function(chunks, model, cfg, contrast_objects,
       dfres <- result$df_residual %||% proj_modmat$dfres
       ar_order <- result$ar_order %||% get_ar_order(cfg)
 
-      bstats <- beta_stats_matrix(
-        betas,
-        XtXinv,
-        sigma_vec,
-        dfres,
-        colnames(modmat),
-        robust_weights = result$robust_weights,
-        ar_order = ar_order
-      )
-
-      conres <- fit_lm_contrasts_fast(
-        betas,
-        sigma_vec^2,
-        XtXinv,
-        simple_conlist_weights,
-        fconlist_weights,
-        dfres,
+      # Compute chunk statistics using shared helper
+      chunk_stats <- compute_chunk_stats(
+        betas = betas,
+        sigma2 = sigma_vec^2,
+        XtXinv = XtXinv,
+        dfres = dfres,
+        varnames = colnames(modmat),
+        simple_conlist_weights = simple_conlist_weights,
+        fconlist_weights = fconlist_weights,
+        event_indices = event_indices,
+        baseline_indices = baseline_indices,
         robust_weights = result$robust_weights,
         ar_order = ar_order
       )
 
       cres[[i]] <- list(
-        bstats = bstats,
-        contrasts = conres,
+        bstats = chunk_stats$bstats,
+        contrasts = chunk_stats$contrasts,
         event_indices = event_indices,
         baseline_indices = baseline_indices,
         ar_coef = result$ar_coef %||% result$phi_hat

--- a/R/fmri_lm_config.R
+++ b/R/fmri_lm_config.R
@@ -114,3 +114,122 @@ get_ar_order <- function(cfg) {
          arp = as.integer(cfg$ar$p %||% 0L),
          0L)
 }
+
+#' Build fmri_lm config from mixed parameter sources
+#'
+#' Consolidates config building logic used by fmri_lm methods.
+#' Handles backward compatibility parameters and option merging.
+#'
+#' @param robust Logical or character ("huber", "bisquare")
+#' @param robust_options List of robust fitting options
+#' @param ar_options List of AR modeling options
+#' @param engine_robust_options Override robust options from engine
+#' @param engine_ar_options Override AR options from engine
+#' @param engine_cfg Pre-built config from engine
+#' @param cor_struct Shorthand for ar_options$struct
+#' @param cor_iter Shorthand for ar_options$iter_gls
+#' @param cor_global Shorthand for ar_options$global
+#' @param ar1_exact_first Shorthand for ar_options$exact_first
+#' @param ar_p Shorthand for ar_options$p
+#' @param ar_voxelwise Shorthand for ar_options$voxelwise
+#' @param robust_psi Shorthand for robust_options$type
+#' @param robust_max_iter Shorthand for robust_options$max_iter
+#' @param robust_scale_scope Shorthand for robust_options$scale_scope
+#' @return An fmri_lm_config object
+#' @keywords internal
+#' @noRd
+build_fmri_lm_cfg <- function(robust = FALSE, robust_options = NULL, ar_options = NULL,
+                               engine_robust_options = NULL, engine_ar_options = NULL,
+                               engine_cfg = NULL,
+                               cor_struct = NULL, cor_iter = NULL, cor_global = NULL,
+                               ar1_exact_first = NULL, ar_p = NULL, ar_voxelwise = FALSE,
+                               robust_psi = NULL, robust_max_iter = NULL,
+                               robust_scale_scope = NULL) {
+
+  # Convert robust parameter to type
+  robust_type <- if (is.logical(robust)) {
+    if (robust) "huber" else FALSE
+  } else {
+    robust
+  }
+
+  # Initialize options lists
+  if (is.null(robust_options)) robust_options <- list()
+  if (is.null(ar_options)) ar_options <- list()
+
+  # Merge engine-supplied options
+  if (!is.null(engine_robust_options)) {
+    robust_options <- utils::modifyList(robust_options, engine_robust_options)
+  }
+  if (!is.null(engine_ar_options)) {
+    ar_options <- utils::modifyList(ar_options, engine_ar_options)
+  }
+
+  # Apply robust type if not already set
+
+  if (!is.null(robust_type) && !("type" %in% names(robust_options))) {
+    robust_options$type <- robust_type
+  }
+
+  # Merge individual robust parameters (backward compatibility)
+  if (!is.null(robust_psi) && !("type" %in% names(robust_options))) {
+    robust_options$type <- robust_psi
+  }
+  if (!is.null(robust_max_iter) && !("max_iter" %in% names(robust_options))) {
+    robust_options$max_iter <- robust_max_iter
+  }
+  if (!is.null(robust_scale_scope) && !("scale_scope" %in% names(robust_options))) {
+    robust_options$scale_scope <- robust_scale_scope
+  }
+
+  # Handle low-rank shorthand order -> struct/p mapping
+  if (!is.null(ar_options$order) && is.null(ar_options$struct)) {
+    ar_order_tmp <- as.integer(ar_options$order[1])
+    if (!is.finite(ar_order_tmp) || ar_order_tmp <= 0L) {
+      ar_options$struct <- "iid"
+    } else if (ar_order_tmp == 1L) {
+      ar_options$struct <- "ar1"
+    } else if (ar_order_tmp == 2L) {
+      ar_options$struct <- "ar2"
+    } else {
+      ar_options$struct <- "arp"
+      ar_options$p <- ar_options$p %||% ar_order_tmp
+    }
+    ar_options$order <- NULL
+  }
+
+  # Merge individual AR parameters (backward compatibility)
+  if (!is.null(cor_struct) && !("struct" %in% names(ar_options))) {
+    ar_options$struct <- cor_struct
+  }
+  if (!is.null(cor_iter) && !("iter_gls" %in% names(ar_options))) {
+    ar_options$iter_gls <- cor_iter
+  }
+  if (!is.null(cor_global) && !("global" %in% names(ar_options))) {
+    ar_options$global <- cor_global
+  }
+  if (!is.null(ar1_exact_first) && !("exact_first" %in% names(ar_options))) {
+    ar_options$exact_first <- ar1_exact_first
+  }
+  if (!is.null(ar_p) && !("p" %in% names(ar_options))) {
+    ar_options$p <- ar_p
+  }
+  if (!("voxelwise" %in% names(ar_options))) {
+    ar_options$voxelwise <- ar_voxelwise
+  }
+
+  # Create config object
+  cfg <- if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
+    engine_cfg
+  } else {
+    fmri_lm_control(robust_options = robust_options, ar_options = ar_options)
+  }
+
+  # Merge with engine_cfg if both provided
+  if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
+    cfg$robust <- engine_cfg$robust
+    cfg$ar <- utils::modifyList(cfg$ar, engine_cfg$ar)
+  }
+
+  cfg
+}

--- a/R/fmri_lm_config.R
+++ b/R/fmri_lm_config.R
@@ -91,3 +91,26 @@ print.fmri_lm_config <- function(x, ...) {
   str(list(robust = x$robust, ar = x$ar), give.attr = FALSE)
   invisible(x)
 }
+
+#' Get AR order from config
+#'
+#' Extracts the autoregressive order from an fmri_lm_config object.
+#' This centralizes the mapping from struct names to numeric order.
+#'
+#' @param cfg An `fmri_lm_config` object or a list with `$ar$struct` and optionally `$ar$p`
+#' @return Integer AR order (0L for iid/none, 1L for ar1, 2L for ar2, etc.)
+#' @keywords internal
+#' @noRd
+get_ar_order <- function(cfg) {
+
+  struct <- cfg$ar$struct %||% "iid"
+  switch(as.character(struct),
+         iid = 0L,
+         none = 0L,
+         ar1 = 1L,
+         ar2 = 2L,
+         ar3 = 3L,
+         ar4 = 4L,
+         arp = as.integer(cfg$ar$p %||% 0L),
+         0L)
+}

--- a/R/fmri_lm_internal.R
+++ b/R/fmri_lm_internal.R
@@ -1,12 +1,119 @@
 # Internal Utilities for fMRI Linear Models
 # Low-level utilities used throughout the fmri_lm implementation
 
+# ============================================================================
+# Default Constants
+# ============================================================================
+
+#' Default chunk sizes for different operations
+#' @keywords internal
+#' @noRd
+.DEFAULT_CHUNK_SIZE_META <- 10000L
+.DEFAULT_CHUNK_SIZE_CONTRAST <- 100L
+.DEFAULT_BLOCK_SIZE_BOOTSTRAP <- 30L
+
+#' Numerical tolerances
+#' @keywords internal
+#' @noRd
+.SVD_TOLERANCE_SCALE <- 1.0
+.MIN_VARIANCE_THRESHOLD <- 1e-10
+
+# ============================================================================
+# Null/Empty Handling Utilities
+# ============================================================================
+
+#' Check if indices are empty (NULL or length 0)
+#' @keywords internal
+#' @noRd
+is_empty_indices <- function(x) {
+  is.null(x) || length(x) == 0L
+}
+
+#' Ensure indices are an integer vector (convert NULL to integer(0))
+#' @keywords internal
+#' @noRd
+as_indices <- function(x) {
+  if (is.null(x)) integer(0L) else as.integer(x)
+}
+
+#' Ensure value is a matrix
+#' @keywords internal
+#' @noRd
+ensure_matrix <- function(x) {
+  if (is.matrix(x)) x else as.matrix(x)
+}
+
+#' Ensure value is a numeric vector
+#' @keywords internal
+#' @noRd
+ensure_numeric <- function(x) {
+  if (is.numeric(x)) x else as.numeric(x)
+}
+
+# ============================================================================
+# Core Utilities
+# ============================================================================
 
 #' Check if object is a formula
 #' @keywords internal
 #' @noRd
 is.formula <- function(x) {
   inherits(x, "formula")
+}
+
+#' Compute chunk statistics (beta stats + contrasts)
+#'
+#' Unified helper for computing statistics from GLM results.
+#' Used by both runwise and chunkwise processing paths.
+#'
+#' @param betas p x V matrix of coefficients
+#' @param sigma2 V-vector of residual variances
+#' @param XtXinv p x p matrix (X'X)^-1
+#' @param dfres Residual degrees of freedom
+#' @param varnames p-vector of coefficient names
+#' @param simple_conlist_weights Named list of simple contrast weight vectors
+#' @param fconlist_weights Named list of F-contrast weight matrices
+#' @param event_indices Indices of event-related parameters
+#' @param baseline_indices Indices of baseline parameters
+#' @param robust_weights Optional vector of robust weights
+#' @param ar_order Order of AR model (0 if none)
+#' @return List with bstats, contrasts, event_indices, baseline_indices
+#' @keywords internal
+#' @noRd
+compute_chunk_stats <- function(betas, sigma2, XtXinv, dfres, varnames,
+                                 simple_conlist_weights, fconlist_weights,
+                                 event_indices, baseline_indices,
+                                 robust_weights = NULL, ar_order = 0L) {
+
+  sigma_vec <- sqrt(sigma2)
+
+  bstats <- beta_stats_matrix(
+    betas,
+    XtXinv,
+    sigma_vec,
+    dfres,
+    varnames,
+    robust_weights = robust_weights,
+    ar_order = ar_order
+  )
+
+  conres <- fit_lm_contrasts_fast(
+    betas,
+    sigma2,
+    XtXinv,
+    simple_conlist_weights,
+    fconlist_weights,
+    dfres,
+    robust_weights = robust_weights,
+    ar_order = ar_order
+  )
+
+  list(
+    bstats = bstats,
+    contrasts = conres,
+    event_indices = event_indices,
+    baseline_indices = baseline_indices
+  )
 }
 
 #' Fast Pre-projection of Design Matrix

--- a/R/fmri_lm_runwise.R
+++ b/R/fmri_lm_runwise.R
@@ -154,49 +154,37 @@ runwise_lm_fast <- function(chunks, model, cfg, simple_conlist_weights, fconlist
                                  simple_conlist_weights, fconlist_weights)
     }
     
-    # Calculate statistics
-    actual_vnames <- colnames(res$X_final)
-    sigma_vec <- sqrt(res$sigma2)
-    
     # Extract robust weights if available
     robust_weights_for_stats <- if (cfg$robust$type != FALSE && !is.null(res$robust_weights)) {
       res$robust_weights
     } else {
       NULL
     }
-    
-    # Beta statistics
-    bstats <- beta_stats_matrix(
-      res$betas, 
-      res$XtXinv, 
-      sigma_vec,
-      res$dfres, 
-      actual_vnames,
+
+    # Compute chunk statistics using shared helper
+    chunk_stats <- compute_chunk_stats(
+      betas = res$betas,
+      sigma2 = res$sigma2,
+      XtXinv = res$XtXinv,
+      dfres = res$dfres,
+      varnames = colnames(res$X_final),
+      simple_conlist_weights = simple_conlist_weights,
+      fconlist_weights = fconlist_weights,
+      event_indices = event_indices,
+      baseline_indices = baseline_indices,
       robust_weights = robust_weights_for_stats,
       ar_order = res$ar_order
     )
-    
-    # Contrast statistics
-    conres <- fit_lm_contrasts_fast(
-      res$betas, 
-      res$sigma2, 
-      res$XtXinv,
-      simple_conlist_weights, 
-      fconlist_weights,
-      res$dfres,
-      robust_weights = robust_weights_for_stats,
-      ar_order = res$ar_order
-    )
-    
+
     cres[[i]] <- list(
-      conres = conres,
-      bstats = bstats,
+      conres = chunk_stats$contrasts,
+      bstats = chunk_stats$bstats,
       event_indices = event_indices,
       baseline_indices = baseline_indices,
       rss = res$rss,
       rdf = res$dfres,
       resvar = res$sigma2,
-      sigma = sigma_vec
+      sigma = sqrt(res$sigma2)
     )
     
     if (progress) cli::cli_progress_update()
@@ -518,20 +506,10 @@ pool_runwise_results <- function(cres, event_indices, baseline_indices, Vu) {
       resvar = resvar
     )
   } else {
-    # Single run - need to combine contrasts into single tibble format
-    # The conres_list[[1]] is a list of contrast tibbles, but we need a single tibble
-    single_contrasts <- conres_list[[1]]
-    
-    if (length(single_contrasts) > 0) {
-      # Combine the list of contrast tibbles into a single tibble
-      combined_contrasts <- dplyr::bind_rows(single_contrasts)
-    } else {
-      # Empty contrasts
-      combined_contrasts <- tibble::tibble()
-    }
-    
+    # Single run - return same structure as multi-run for consistency
+    # conres_list[[1]] is already a list of contrast tibbles
     list(
-      contrasts = combined_contrasts,  # Single tibble with all contrasts
+      contrasts = conres_list[[1]],  # List of contrast tibbles (same as meta_contrasts)
       betas = bstats_list[[1]],
       event_indices = event_indices,
       baseline_indices = baseline_indices,

--- a/R/fmri_lm_runwise.R
+++ b/R/fmri_lm_runwise.R
@@ -129,12 +129,8 @@ runwise_lm_fast <- function(chunks, model, cfg, simple_conlist_weights, fconlist
                            sigma_fixed = NULL, verbose = FALSE, progress = FALSE) {
   
   cres <- vector("list", length(chunks))
-  ar_order <- switch(cfg$ar$struct,
-                     ar1 = 1L,
-                     ar2 = 2L,
-                     arp = cfg$ar$p,
-                     iid = 0L)
-  
+  ar_order <- get_ar_order(cfg)
+
   for (i in seq_along(chunks)) {
     ym <- chunks[[i]]
     if (verbose) message("Processing run (fast path) ", ym$chunk_num)
@@ -264,12 +260,8 @@ runwise_lm_voxelwise <- function(chunks, model, cfg, simple_conlist_weights, fco
                                 verbose = FALSE, progress = FALSE, 
                                 parallel_voxels = FALSE) {
   
-  ar_order <- switch(cfg$ar$struct,
-                     ar1 = 1L,
-                     ar2 = 2L,
-                     arp = cfg$ar$p,
-                     iid = 0L)
-  
+  ar_order <- get_ar_order(cfg)
+
   if (verbose) message("Using voxelwise AR(", ar_order, ") modeling...")
   
   cres <- vector("list", length(chunks))

--- a/R/fmri_lm_strategies.R
+++ b/R/fmri_lm_strategies.R
@@ -30,12 +30,8 @@ process_run_standard <- function(run_chunk, model, cfg, phi_fixed = NULL,
   proj_run <- .fast_preproject(X_run)
   
   # AR modeling if needed
-  ar_order <- switch(cfg$ar$struct,
-                     ar1 = 1L,
-                     ar2 = 2L,
-                     arp = cfg$ar$p,
-                     iid = 0L)
-  
+  ar_order <- get_ar_order(cfg)
+
   if (cfg$ar$struct != "iid") {
     # Estimate AR parameters
     phi_hat_run <- if (!is.null(phi_fixed)) {
@@ -199,12 +195,8 @@ process_run_ar_robust <- function(run_chunk, model, cfg, phi_fixed = NULL, sigma
   proj_run <- .fast_preproject(X_run)
   
   # AR order
-  ar_order <- switch(cfg$ar$struct,
-                     ar1 = 1L,
-                     ar2 = 2L,
-                     arp = cfg$ar$p,
-                     iid = 0L)
-  
+  ar_order <- get_ar_order(cfg)
+
   # Step 1: Initial OLS for AR parameter estimation
   glm_ctx_orig <- glm_context(X = X_run, Y = Y_run, proj = proj_run)
   
@@ -362,12 +354,8 @@ prepare_chunkwise_matrices <- function(model, dataset, cfg, phi_fixed = NULL, si
   run_row_inds <- lapply(run_chunks, `[[`, "row_ind")
   
   # AR order
-  ar_order <- switch(cfg$ar$struct,
-                     ar1 = 1L,
-                     ar2 = 2L,
-                     arp = cfg$ar$p,
-                     iid = 0L)
-  
+  ar_order <- get_ar_order(cfg)
+
   ar_modeling <- cfg$ar$struct != "iid"
   
   # Pre-compute per-run information

--- a/R/fmri_robust_fitting.R
+++ b/R/fmri_robust_fitting.R
@@ -90,8 +90,10 @@ robust_iterative_fitter <- function(initial_glm_ctx,
     u <- row_med / sigma_hat
     
     # Calculate weights based on psi function
+    # Protect against division by zero when residuals are exactly 0
+    u_safe <- pmax(abs(u), .Machine$double.eps)
     w <- switch(psi_type,
-                huber = pmin(1, k_huber / abs(u)),
+                huber = pmin(1, k_huber / u_safe),
                 bisquare = ifelse(abs(u) <= c_tukey,
                                   (1 - (u / c_tukey)^2)^2,
                                   0))
@@ -128,8 +130,10 @@ robust_iterative_fitter <- function(initial_glm_ctx,
   
   # Final weights for output
   u_final <- row_med_final / sigma_robust
+  # Protect against division by zero when residuals are exactly 0
+  u_final_safe <- pmax(abs(u_final), .Machine$double.eps)
   w_final <- switch(psi_type,
-                    huber = pmin(1, k_huber / abs(u_final)),
+                    huber = pmin(1, k_huber / u_final_safe),
                     bisquare = ifelse(abs(u_final) <= c_tukey,
                                       (1 - (u_final / c_tukey)^2)^2,
                                       0))

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -1289,11 +1289,6 @@ unpack_chunkwise <- function(cres, event_indices, baseline_indices) {
     con <- dplyr::tibble() # Return empty tibble if no contrasts
   }
 
-  # --- DEBUG FINAL CONTRAST TIBBLE ---
-  # message("Structure of final 'con' tibble before returning from unpack_chunkwise:")
-  # print(str(con))
-  # --- END DEBUG ---
-
   list(
     betas = cbetas_out,
     contrasts = con,

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -1588,29 +1588,27 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
               # Calculate statistics
               actual_vnames <- colnames(X_global_final_w)
               
-              # For sigma, we need to map run-specific sigmas to voxels
-              # This is a simplification - in practice, we might need per-run statistics
-              sigma_vec <- sqrt(res$sigma2)
-              
-              bstats <- beta_stats_matrix(res$betas, 
-                                         proj_global_final_w$XtXinv, 
-                                         sigma_vec,
-                                         proj_global_final_w$dfres, 
-                                         actual_vnames)
-              
-              contrasts <- fit_lm_contrasts_fast(res$betas, 
-                                               res$sigma2, 
-                                               proj_global_final_w$XtXinv,
-                                               simple_conlist_weights, 
-                                               fconlist_weights, 
-                                               proj_global_final_w$dfres)
-              
-              cres[[i]] <- list(bstats = bstats,
-                               contrasts = contrasts,
-                               rss = res$rss,
-                               rdf = proj_global_robustly_weighted$dfres,
-                               sigma = sigma_vec,
-                               ar_coef = NULL)
+              # Compute chunk statistics using shared helper
+              chunk_stats <- compute_chunk_stats(
+                betas = res$betas,
+                sigma2 = res$sigma2,
+                XtXinv = proj_global_final_w$XtXinv,
+                dfres = proj_global_final_w$dfres,
+                varnames = actual_vnames,
+                simple_conlist_weights = simple_conlist_weights,
+                fconlist_weights = fconlist_weights,
+                event_indices = event_indices,
+                baseline_indices = baseline_indices
+              )
+
+              cres[[i]] <- list(
+                bstats = chunk_stats$bstats,
+                contrasts = chunk_stats$contrasts,
+                rss = res$rss,
+                rdf = proj_global_robustly_weighted$dfres,
+                sigma = sqrt(res$sigma2),
+                ar_coef = NULL
+              )
                                
               if (progress) cli::cli_progress_update(id = pb)
           }
@@ -1703,21 +1701,28 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
           glm_ctx_chunk <- glm_context(X = modmat, Y = Ymat, proj = proj)
           res <- solve_glm_core(glm_ctx_chunk)
 
-          actual_vnames <- colnames(modmat)
-          sigma_vec <- sqrt(res$sigma2)
-          bstats <- beta_stats_matrix(res$betas, proj$XtXinv, sigma_vec, proj$dfres, actual_vnames,
-                                       robust_weights = NULL, ar_order = ar_order)
+          # Compute chunk statistics using shared helper
+          chunk_stats <- compute_chunk_stats(
+            betas = res$betas,
+            sigma2 = res$sigma2,
+            XtXinv = proj$XtXinv,
+            dfres = proj$dfres,
+            varnames = colnames(modmat),
+            simple_conlist_weights = simple_conlist_weights,
+            fconlist_weights = fconlist_weights,
+            event_indices = event_indices,
+            baseline_indices = baseline_indices,
+            ar_order = ar_order
+          )
 
-          contrasts <- fit_lm_contrasts_fast(res$betas, res$sigma2, proj$XtXinv,
-                                             simple_conlist_weights, fconlist_weights, proj$dfres,
-                                             robust_weights = NULL, ar_order = ar_order)
-
-          cres[[i]] <- list(bstats = bstats,
-                            contrasts = contrasts,
-                            rss = res$rss,
-                            rdf = proj$dfres,
-                            sigma = sigma_vec,
-                            ar_coef = NULL)
+          cres[[i]] <- list(
+            bstats = chunk_stats$bstats,
+            contrasts = chunk_stats$contrasts,
+            rss = res$rss,
+            rdf = proj$dfres,
+            sigma = sqrt(res$sigma2),
+            ar_coef = NULL
+          )
           if (progress) cli::cli_progress_update(id = pb)
       }
       # -------- End New Fast Path --------

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -355,107 +355,25 @@ fmri_lm.formula <- function(formula, block, baseline_model = NULL, dataset, dura
     assert_that(is.numeric(nchunks) && nchunks > 0, msg = "'nchunks' must be a positive number")
   }
   
-  # Convert robust parameter to type for config
-  if (is.logical(robust)) {
-    robust_type <- if (robust) "huber" else FALSE
-  } else {
-    robust_type <- robust
-  }
-  
-  # Merge engine-supplied option overrides into the explicit arguments
-  if (!is.null(engine_robust_options)) {
-    if (is.null(robust_options)) {
-      robust_options <- engine_robust_options
-    } else {
-      robust_options <- utils::modifyList(robust_options, engine_robust_options)
-    }
-  }
+  # Build configuration using shared helper
+  cfg <- build_fmri_lm_cfg(
+    robust = robust,
+    robust_options = robust_options,
+    ar_options = ar_options,
+    engine_robust_options = engine_robust_options,
+    engine_ar_options = engine_ar_options,
+    engine_cfg = engine_cfg,
+    cor_struct = cor_struct,
+    cor_iter = cor_iter,
+    cor_global = cor_global,
+    ar1_exact_first = ar1_exact_first,
+    ar_p = ar_p,
+    ar_voxelwise = ar_voxelwise,
+    robust_psi = robust_psi,
+    robust_max_iter = robust_max_iter,
+    robust_scale_scope = robust_scale_scope
+  )
 
-  if (!is.null(engine_ar_options)) {
-    if (is.null(ar_options)) {
-      ar_options <- engine_ar_options
-    } else {
-      ar_options <- utils::modifyList(ar_options, engine_ar_options)
-    }
-  }
-
-  if (is.null(robust_options)) {
-    robust_options <- list()
-  }
-  if (!is.null(engine_robust_options)) {
-    robust_options <- utils::modifyList(robust_options, engine_robust_options)
-  }
-  if (!is.null(robust_type) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_type
-  }
-  
-  # Merge individual robust parameters for backward compatibility
-  if (!is.null(robust_psi) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_psi
-  }
-  if (!is.null(robust_max_iter) && !("max_iter" %in% names(robust_options))) {
-    robust_options$max_iter <- robust_max_iter
-  }
-  if (!is.null(robust_scale_scope) && !("scale_scope" %in% names(robust_options))) {
-    robust_options$scale_scope <- robust_scale_scope
-  }
-  
-  # Allow low-rank shorthand `order` to map into struct/p
-  if (!is.null(ar_options$order) && is.null(ar_options$struct)) {
-    ar_order_tmp <- as.integer(ar_options$order[1])
-    if (!is.finite(ar_order_tmp) || ar_order_tmp <= 0L) {
-      ar_options$struct <- "iid"
-    } else if (ar_order_tmp == 1L) {
-      ar_options$struct <- "ar1"
-    } else if (ar_order_tmp == 2L) {
-      ar_options$struct <- "ar2"
-    } else {
-      ar_options$struct <- "arp"
-      ar_options$p <- ar_options$p %||% ar_order_tmp
-    }
-  }
-  ar_options$order <- NULL
-  
-  if (is.null(ar_options)) {
-    ar_options <- list()
-  }
-  if (!is.null(engine_ar_options)) {
-    ar_options <- utils::modifyList(ar_options, engine_ar_options)
-  }
-
-  # Merge individual AR parameters for backward compatibility
-  if (!is.null(cor_struct) && !("struct" %in% names(ar_options))) {
-    ar_options$struct <- cor_struct
-  }
-  if (!is.null(cor_iter) && !("iter_gls" %in% names(ar_options))) {
-    ar_options$iter_gls <- cor_iter
-  }
-  if (!is.null(cor_global) && !("global" %in% names(ar_options))) {
-    ar_options$global <- cor_global
-  }
-  if (!is.null(ar1_exact_first) && !("exact_first" %in% names(ar_options))) {
-    ar_options$exact_first <- ar1_exact_first
-  }
-  if (!is.null(ar_p) && !("p" %in% names(ar_options))) {
-    ar_options$p <- ar_p
-  }
-  if (!("voxelwise" %in% names(ar_options))) {
-    ar_options$voxelwise <- ar_voxelwise
-  }
-  
-  # Create configuration object
-  cfg <- if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    engine_cfg
-  } else {
-    fmri_lm_control(robust_options = robust_options, ar_options = ar_options)
-  }
-
-  # If both were supplied, prefer the merged configuration but keep engine_cfg metadata
-  if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    cfg$robust <- engine_cfg$robust
-    cfg$ar <- utils::modifyList(cfg$ar, engine_cfg$ar)
-  }
-  
   model <- create_fmri_model(formula, block, baseline_model, dataset, durations = durations, drop_empty = drop_empty)
 
   if (!is.null(engine)) {
@@ -561,75 +479,24 @@ fmri_lm.fmri_model <- function(formula, dataset = NULL,
   }
   assert_that(inherits(dataset, "fmri_dataset"))
 
-  if (is.logical(robust)) {
-    robust_type <- if (robust) "huber" else FALSE
-  } else {
-    robust_type <- robust
-  }
-
-  if (is.null(robust_options)) {
-    robust_options <- list()
-  }
-  if (!is.null(robust_type) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_type
-  }
-  if (!is.null(robust_psi) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_psi
-  }
-  if (!is.null(robust_max_iter) && !("max_iter" %in% names(robust_options))) {
-    robust_options$max_iter <- robust_max_iter
-  }
-  if (!is.null(robust_scale_scope) && !("scale_scope" %in% names(robust_options))) {
-    robust_options$scale_scope <- robust_scale_scope
-  }
-
-  if (is.null(ar_options)) {
-    ar_options <- list()
-  }
-  if (!is.null(cor_struct) && !("struct" %in% names(ar_options))) {
-    ar_options$struct <- cor_struct
-  }
-  if (!is.null(cor_iter) && !("iter_gls" %in% names(ar_options))) {
-    ar_options$iter_gls <- cor_iter
-  }
-  if (!is.null(cor_global) && !("global" %in% names(ar_options))) {
-    ar_options$global <- cor_global
-  }
-  if (!is.null(ar1_exact_first) && !("exact_first" %in% names(ar_options))) {
-    ar_options$exact_first <- ar1_exact_first
-  }
-  if (!is.null(ar_p) && !("p" %in% names(ar_options))) {
-    ar_options$p <- ar_p
-  }
-  if (!("voxelwise" %in% names(ar_options))) {
-    ar_options$voxelwise <- ar_voxelwise
-  }
-
-  if (!is.null(ar_options$order) && is.null(ar_options$struct)) {
-    ar_order_tmp <- as.integer(ar_options$order[1])
-    if (!is.finite(ar_order_tmp) || ar_order_tmp <= 0L) {
-      ar_options$struct <- "iid"
-    } else if (ar_order_tmp == 1L) {
-      ar_options$struct <- "ar1"
-    } else if (ar_order_tmp == 2L) {
-      ar_options$struct <- "ar2"
-    } else {
-      ar_options$struct <- "arp"
-      ar_options$p <- ar_options$p %||% ar_order_tmp
-    }
-  }
-  ar_options$order <- NULL
-
-  cfg <- if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    engine_cfg
-  } else {
-    fmri_lm_control(robust_options = robust_options, ar_options = ar_options)
-  }
-
-  if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    cfg$robust <- engine_cfg$robust
-    cfg$ar <- utils::modifyList(cfg$ar, engine_cfg$ar)
-  }
+  # Build configuration using shared helper
+  cfg <- build_fmri_lm_cfg(
+    robust = robust,
+    robust_options = robust_options,
+    ar_options = ar_options,
+    engine_robust_options = engine_robust_options,
+    engine_ar_options = engine_ar_options,
+    engine_cfg = engine_cfg,
+    cor_struct = cor_struct,
+    cor_iter = cor_iter,
+    cor_global = cor_global,
+    ar1_exact_first = ar1_exact_first,
+    ar_p = ar_p,
+    ar_voxelwise = ar_voxelwise,
+    robust_psi = robust_psi,
+    robust_max_iter = robust_max_iter,
+    robust_scale_scope = robust_scale_scope
+  )
 
   if (!is.null(engine)) {
     plugin <- get_engine(engine)

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -724,10 +724,7 @@ fmri_lm_fit <- function(fmrimod, dataset, strategy = c("runwise", "chunkwise"),
   phi_global <- NULL
   sigma_global <- NULL
   if (cfg$ar$global && cfg$ar$struct != "iid") {
-    ar_order <- switch(cfg$ar$struct,
-                       ar1 = 1L,
-                       ar2 = 2L,
-                       arp = cfg$ar$p)
+    ar_order <- get_ar_order(cfg)
 
     chunk_iter <- exec_strategy("runwise")(dataset)
     run_chunks <- collect_chunks(chunk_iter)
@@ -1385,12 +1382,8 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
       if (cfg$robust$type != FALSE) {
           # Combined AR + Robust path for chunkwise
           ar_modeling <- cfg$ar$struct != "iid"
-          ar_order <- switch(cfg$ar$struct,
-                             ar1 = 1L,
-                             ar2 = 2L,
-                             arp = cfg$ar$p,
-                             iid = 0L)
-          
+          ar_order <- get_ar_order(cfg)
+
           if (ar_modeling) {
               message("Using fast path with AR + robust weighting...")
           } else {
@@ -1637,11 +1630,7 @@ chunkwise_lm.fmri_dataset_old <- function(dset, model, contrast_objects, nchunks
       modmat_orig <- model.matrix(as.formula(form), data_env)
 
       ar_modeling <- cfg$ar$struct != "iid"
-      ar_order <- switch(cfg$ar$struct,
-                         ar1 = 1L,
-                         ar2 = 2L,
-                         arp = cfg$ar$p,
-                         iid = 0L)
+      ar_order <- get_ar_order(cfg)
 
       chunk_iter <- exec_strategy("runwise")(dset)
       run_chunks <- collect_chunks(chunk_iter)
@@ -1869,11 +1858,7 @@ runwise_lm <- function(dset, model, contrast_objects, cfg, verbose = FALSE,
           }
       } else if (cfg$ar$voxelwise && cfg$ar$struct != "iid") {
           # Voxelwise AR path using modular solver
-          ar_order <- switch(cfg$ar$struct,
-                             ar1 = 1L,
-                             ar2 = 2L,
-                             arp = cfg$ar$p,
-                             iid = 0L)
+          ar_order <- get_ar_order(cfg)
 
           simple_conlist <- Filter(function(x) inherits(x, "contrast"), contrast_objects)
           fconlist <- Filter(function(x) inherits(x, "Fcontrast"), contrast_objects)
@@ -2045,12 +2030,8 @@ runwise_lm <- function(dset, model, contrast_objects, cfg, verbose = FALSE,
       message("Using fast path for runwise LM...")
 
       ar_modeling <- cfg$ar$struct != "iid"
-      ar_order <- switch(cfg$ar$struct,
-                         ar1 = 1L,
-                         ar2 = 2L,
-                         arp = cfg$ar$p,
-                         iid = 0L)
-      
+      ar_order <- get_ar_order(cfg)
+
       # .export needed? conlist, fcon, model should be available.
       # Add functions from this package? .packages = c("dplyr", "purrr", "fmrireg")? Or rely on namespace?
       cres <- vector("list", length(chunks))

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -1,6 +1,48 @@
 # Group Data Structures for Meta-Analysis
 # Generic constructor and format dispatch for group-level fMRI data
 
+# ============================================================================
+# Validation Helpers
+# ============================================================================
+
+#' Check for required fields in a group_data object
+#'
+#' @param x Object to validate
+#' @param required_fields Character vector of required field names
+#' @param context Optional context string for error messages
+#' @return Invisible TRUE if valid, error otherwise
+#' @keywords internal
+#' @noRd
+check_required_fields <- function(x, required_fields, context = NULL) {
+  missing_fields <- setdiff(required_fields, names(x))
+  if (length(missing_fields) > 0) {
+    prefix <- if (!is.null(context)) paste0(context, ": ") else ""
+    stop(prefix, "Missing required fields: ",
+         paste(missing_fields, collapse = ", "), call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+#' Validate that a field is of expected type
+#'
+#' @param x Value to check
+#' @param field_name Name of field (for error message)
+#' @param expected_type Character string describing expected type
+#' @param check_fn Function that returns TRUE if type is valid
+#' @return Invisible TRUE if valid, error otherwise
+#' @keywords internal
+#' @noRd
+check_field_type <- function(x, field_name, expected_type, check_fn) {
+  if (!check_fn(x)) {
+    stop("'", field_name, "' must be ", expected_type, call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
+# ============================================================================
+# Main Constructor
+# ============================================================================
+
 #' Create Group Dataset for Meta-Analysis
 #'
 #' Generic constructor that creates a group dataset from various input formats
@@ -101,19 +143,13 @@ validate_group_data <- function(x) {
   if (!inherits(x, "group_data")) {
     stop("Object must be of class 'group_data'", call. = FALSE)
   }
-  
-  # Check required fields
-  required_fields <- c("format", "subjects")
-  missing_fields <- setdiff(required_fields, names(x))
-  if (length(missing_fields) > 0) {
-    stop("Missing required fields: ", paste(missing_fields, collapse = ", "), 
-         call. = FALSE)
-  }
-  
-  # Validate subjects
-  if (!is.character(x$subjects) && !is.factor(x$subjects)) {
-    stop("'subjects' must be a character vector or factor", call. = FALSE)
-  }
+
+  # Check required fields using helper
+  check_required_fields(x, c("format", "subjects"))
+
+  # Validate subjects type
+  check_field_type(x$subjects, "subjects", "a character vector or factor",
+                   function(v) is.character(v) || is.factor(v))
   
   # Format-specific validation
   if (inherits(x, "group_data_h5")) {

--- a/R/group_data_csv.R
+++ b/R/group_data_csv.R
@@ -345,23 +345,15 @@ get_contrasts <- function(gd) {
 #' @keywords internal
 #' @noRd
 validate_group_data_csv <- function(x) {
-  # Check for required fields
-  required_fields <- c("data", "effect_cols", "subject_col", "subjects", "format")
-  missing_fields <- setdiff(required_fields, names(x))
-  if (length(missing_fields) > 0) {
-    stop("Missing required fields for group_data_csv: ",
-         paste(missing_fields, collapse = ", "), call. = FALSE)
-  }
-  
-  # Validate data is a data frame
-  if (!is.data.frame(x$data)) {
-    stop("'data' must be a data frame", call. = FALSE)
-  }
-  
-  # Validate effect_cols structure
-  if (!is.list(x$effect_cols) || is.null(names(x$effect_cols))) {
-    stop("'effect_cols' must be a named list", call. = FALSE)
-  }
-  
+  # Check for required fields using helper
+  check_required_fields(x,
+    c("data", "effect_cols", "subject_col", "subjects", "format"),
+    context = "group_data_csv")
+
+  # Validate field types
+  check_field_type(x$data, "data", "a data frame", is.data.frame)
+  check_field_type(x$effect_cols, "effect_cols", "a named list",
+                   function(v) is.list(v) && !is.null(names(v)))
+
   invisible(TRUE)
 }

--- a/R/group_data_h5.R
+++ b/R/group_data_h5.R
@@ -315,19 +315,16 @@ read_h5_full <- function(gd, stat = NULL) {
 #' @keywords internal
 #' @noRd
 validate_group_data_h5 <- function(x) {
-  # Check for required fields
-  required_fields <- c("paths", "subjects", "format", "dim", "labels")
-  missing_fields <- setdiff(required_fields, names(x))
-  if (length(missing_fields) > 0) {
-    stop("Missing required fields for group_data_h5: ", 
-         paste(missing_fields, collapse = ", "), call. = FALSE)
-  }
-  
+  # Check for required fields using helper
+  check_required_fields(x,
+    c("paths", "subjects", "format", "dim", "labels"),
+    context = "group_data_h5")
+
   # Validate paths and subjects have same length
   if (length(x$paths) != length(x$subjects)) {
     stop("Length of paths and subjects must match", call. = FALSE)
   }
-  
+
   invisible(TRUE)
 }
 


### PR DESCRIPTION
- Fix division by zero in Huber weighting (fmri_robust_fitting.R)
  When residuals are exactly 0, abs(u) would be 0 causing division
  by zero. Added protection using pmax with machine epsilon.

- Fix undefined variable xf in estimate_hrf (fmri_betas.R)
  The variable xf was used in predict() but its definition was
  commented out, causing runtime errors when has_fixed=TRUE.
  Properly handle both has_fixed=TRUE and has_fixed=FALSE cases.

- Fix bootstrap block size edge case (bootstrap.R)
  When nrows < block_size, nblocks becomes 0 and rep(1:0, ...)
  causes unexpected behavior. Now handles this by using a single
  block when nblocks < 1.

- Change silent zero fallback to warning with NA (fmri_betas.R)
  When mixed model solvers fail, returning zeros silently could
  produce misleading results. Now returns NA_real_ with warning
  to make failures visible.

- Remove debug code and commented browser() statements