### PR TITLE
Fix voxelwise contrast image extraction

### DIFF
--- a/R/bids_export.R
+++ b/R/bids_export.R
@@ -854,7 +854,7 @@ write_results.fmri_lm <- function(x,
       # Vectorized assignment using mask indices
       for (j in seq_along(available_stats)) {
         internal_stat_name <- mapped_stats[j]
-        stat_values <- contrast_data[[internal_stat_name]][[1]]
+        stat_values <- as.vector(contrast_data[[internal_stat_name]])
         if (length(stat_values) != n_mask_voxels) {
           stop(
             "Statistic '", available_stats[[j]], "' for contrast '", contrast_name,
@@ -933,7 +933,7 @@ write_results.fmri_lm <- function(x,
 
       for (j in seq_along(available_stats)) {
         internal_stat_name <- mapped_stats[j]
-        stat_values <- contrast_data[[internal_stat_name]][[1]]
+        stat_values <- as.vector(contrast_data[[internal_stat_name]])
         if (length(stat_values) != n_mask_voxels) {
           stop(
             "Statistic '", available_stats[[j]], "' for contrast '", contrast_name,

--- a/R/fmri_lm_methods.R
+++ b/R/fmri_lm_methods.R
@@ -148,11 +148,13 @@ standard_error.fmri_lm <- function(x, type = c("estimates", "contrasts"),...) {
   }
 
   cols <- lapply(key_cols, function(nm) {
-    mats <- nested[[nm]]
-    if (length(mats) == 0 || is.null(mats[[1]])) {
+    values <- nested[[nm]]
+    if (length(values) == 0 || is.null(values[[1]])) {
       NULL
+    } else if (block == "betas") {
+      values[[1]]
     } else {
-      mats[[1]]
+      as.vector(values)
     }
   })
   names(cols) <- key_cols
@@ -452,12 +454,12 @@ coef_image.fmri_lm <- function(object, coef = 1,
   } else if (type == "contrasts") {
     ct <- object$result$contrasts
     simple <- ct[ct$type == "contrast", , drop = FALSE]
-    values <- simple$data[[idx]][[element]][[1]]
+    values <- as.vector(simple$data[[idx]][[element]])
   } else {
     # F-contrasts
     ct <- object$result$contrasts
     fcons <- ct[ct$type == "Fcontrast", , drop = FALSE]
-    values <- fcons$data[[idx]][[element]][[1]]
+    values <- as.vector(fcons$data[[idx]][[element]])
   }
 
   # ---- reconstruct spatial image if possible ----

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -1189,9 +1189,7 @@ pull_stat_revised <- function(x, type, element) {
       stop("No simple contrasts for this model.")
     }
     cnames <- ret$name
-    # Extract the specific element (e.g., estimate), which is a list(vector)
-    # Then extract the vector itself (element [[1]]) before binding
-    out <- lapply(ret$data, function(inner_tibble) inner_tibble[[element]][[1]]) %>% 
+    out <- lapply(ret$data, function(inner_tibble) inner_tibble[[element]]) %>%
              dplyr::bind_cols()
     names(out) <- cnames
     out
@@ -1201,9 +1199,7 @@ pull_stat_revised <- function(x, type, element) {
       stop("No F contrasts for this model.")
     }
     cnames <- ret$name
-    # Extract the specific element (e.g., estimate), which is list(vector)
-    # Then extract the vector itself (element [[1]]) before binding
-    out <- lapply(ret$data, function(inner_tibble) inner_tibble[[element]][[1]]) %>% 
+    out <- lapply(ret$data, function(inner_tibble) inner_tibble[[element]]) %>%
              dplyr::bind_cols()
     names(out) <- cnames
     out
@@ -1515,15 +1511,16 @@ unpack_chunkwise <- function(cres, event_indices, baseline_indices) {
             prob_full <- dat$prob
             sigma_full <- if ("sigma" %in% names(dat)) dat$sigma else NULL
             
-            # Re-package combined data for this contrast
+            # Re-package combined data using the canonical contrast schema:
+            # one row per voxel and one atomic column per statistic.
             combined_data_tibble <- dplyr::tibble(
-                estimate = list(estimate_full), 
-                se = list(se_full),             
-                stat = list(stat_full),          
-                prob = list(prob_full)           
+                estimate = estimate_full,
+                se = se_full,
+                stat = stat_full,
+                prob = prob_full
             )
             if (!is.null(sigma_full)) {
-                combined_data_tibble$sigma = list(sigma_full)
+                combined_data_tibble$sigma = sigma_full
             }
 
             # Take metadata from the first chunk's entry for this contrast

--- a/tests/testthat/test_write_results.R
+++ b/tests/testthat/test_write_results.R
@@ -1240,14 +1240,14 @@ test_that("write_results.fmri_lm handles fmristore write failure gracefully", {
 # (type = "Fcontrast", stat_type = "Fstat", data with estimate/se/stat/prob).
 add_synthetic_fcontrast <- function(mod, name = "condF") {
   ct <- mod$result$contrasts
-  n_vox <- length(ct$data[[1]]$stat[[1]])
+  n_vox <- length(ct$data[[1]]$stat)
   set.seed(7)
   f_data <- tibble::tibble(
-    estimate = list(runif(n_vox, 0.5, 3)),   # numerator mean square
-    se       = list(rep(1, n_vox)),          # denominator mean square (sigma2)
-    stat     = list(runif(n_vox, 2, 12)),    # F statistic (non-negative)
-    prob     = list(runif(n_vox, 1e-4, 0.2)),
-    sigma    = list(rep(1, n_vox))
+    estimate = runif(n_vox, 0.5, 3),   # numerator mean square
+    se       = rep(1, n_vox),          # denominator mean square (sigma2)
+    stat     = runif(n_vox, 2, 12),    # F statistic (non-negative)
+    prob     = runif(n_vox, 1e-4, 0.2),
+    sigma    = rep(1, n_vox)
   )
   f_row <- tibble::tibble(
     contrast_internal_name = name,
@@ -1398,4 +1398,46 @@ test_that("coef_images supports contrasts and a coef subset", {
     coef_images(mod, type = "estimates", coefs = "not_a_real_coef"),
     "not found"
   )
+})
+
+test_that("coef_image preserves voxelwise simple-contrast statistics", {
+  mod <- create_test_fmri_lm()
+  ct <- mod$result$contrasts
+  simple_idx <- which(ct$type == "contrast")[1]
+  contrast_name <- ct$name[[simple_idx]]
+  elements <- c(estimate = "estimate", se = "se", tstat = "stat", prob = "prob")
+
+  for (statistic in names(elements)) {
+    stored <- ct$data[[simple_idx]][[elements[[statistic]]]]
+    expected <- as.numeric(unlist(stored, recursive = TRUE, use.names = FALSE))
+    img <- coef_image(mod, coef = contrast_name, statistic = statistic,
+                      type = "contrasts")
+    actual <- as.numeric(as.array(img))
+
+    expect_length(actual, length(expected))
+    expect_equal(actual, expected, info = statistic)
+    expect_gt(length(unique(actual)), 1)
+  }
+})
+
+test_that("coef_image preserves voxelwise F-contrast statistics", {
+  mod <- add_synthetic_fcontrast(create_test_fmri_lm())
+  ct <- mod$result$contrasts
+  f_idx <- which(ct$type == "Fcontrast")[1]
+  f_name <- ct$name[[f_idx]]
+  elements <- c(estimate = "estimate", se = "se", tstat = "stat", prob = "prob")
+
+  mod$result$contrasts$data[[f_idx]]$se <-
+    seq_along(mod$result$contrasts$data[[f_idx]]$se) / 10
+
+  for (statistic in names(elements)) {
+    stored <- mod$result$contrasts$data[[f_idx]][[elements[[statistic]]]]
+    expected <- as.numeric(stored)
+    img <- coef_image(mod, coef = f_name, statistic = statistic, type = "F")
+    actual <- as.numeric(as.array(img))
+
+    expect_length(actual, length(expected))
+    expect_equal(actual, expected, info = statistic)
+    expect_gt(length(unique(actual)), 1)
+  }
 })


### PR DESCRIPTION
Fixes #201.

## What changed

- preserve complete voxel vectors when reconstructing simple- and F-contrast coefficient images
- standardize chunkwise contrast result tables on atomic voxel-length statistic columns
- preserve full contrast vectors in HDF5 and NIfTI exporters and tidy extraction
- add value-level regressions for `estimate`, `se`, `tstat`, and `prob`

## Root cause

Contrast consumers applied `[[1]]` to statistic columns. For atomic or matrix-backed voxel statistics, that selected a single scalar, which was then recycled across the model mask.

## Validation

- `tests/testthat/test_write_results.R`: 204 passed, 0 failed, 0 warnings
- chunkwise, tidy, rank-deficient contrast, and F-contrast focused suites: 40 passed
- `git diff --check`