### PR TITLE
Correct AR degrees of freedom, argument precedence, and sandwich meat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,15 @@ All 6 critical tests now pass:
 - ✓ Sandwich variance estimator
 
 The refactored code is now ready for integration with the existing codebase.
+
+### Correction (2026-08-07)
+
+The "sandwich variance estimator" item above overstated what shipped. Both
+sandwich helpers (`compute_sandwich_variance`, `calculate_sandwich_variance`)
+are reachable only by direct call — no `fmri_lm()` path invokes them, and the
+robust path reports a model-based WLS variance instead. The test that covered
+them asserted only dimensions and positivity, which is why an arithmetic error
+(`X'diag(e^4)X` in place of `X'diag(e^2)X`, giving standard errors 3.5x too
+large) survived in `compute_sandwich_variance` until 2026-08-07. That error is
+now fixed and both helpers are checked against `sandwich::vcovHC` in
+`tests/testthat/test-variance-closed-form.R`; they remain unwired.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ LazyData: false
 Depends:
     R (>= 4.0.0)
 Imports:
-    fmriAR,
+    fmriAR (>= 0.3.3),
     fmrigds,
     fmridesign (>= 0.1.0),
     fmrihrf (>= 0.1.0),
@@ -80,6 +80,7 @@ Suggests:
     jsonlite
 Remotes:
     bbuchsbaum/bidser,
+    bbuchsbaum/fmriAR,
     bbuchsbaum/fmristore,
     bbuchsbaum/fmrigds@f015b7c7fa5008e2435d269aeb1882a9aa24eaf0,
     anthonynorth/roxyglobals,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,75 @@
 # fmrireg 0.2.0
 
+## Statistical Corrections
+
+* **AR degrees of freedom.** `fmri_lm()` no longer deflates the residual
+  degrees of freedom when an AR structure is used. The previous adjustment
+  multiplied `n - p` by `1 / (1 + 2 * sum(1 - k/n))`, which is the variance
+  inflation one would obtain if *every* autocorrelation equalled 1. It never
+  depended on the fitted AR coefficients — at `n = 200`, `p = 12`, AR(1) it
+  returned 62.9 whether the true autocorrelation was 0.05 or 0.9 — and it was
+  applied on top of prewhitening, double-counting a correction already made.
+
+  **This changes reported AR p-values.** They become less conservative;
+  degrees of freedom roughly triple for AR(1). The previous behaviour cost
+  statistical power rather than inflating false positives, so results that
+  were significant before remain significant, but p-values and any
+  power-sensitive analyses will differ from earlier versions.
+
+  `calculate_effective_df()` gains a working `method = "satterthwaite"`
+  (previously a verbatim duplicate of `method = "simple"`) that computes
+  `tr(RV)^2 / tr(RVRV)` from a supplied design and post-whitening covariance,
+  reducing exactly to `n - p` when the errors are uncorrelated. Residual
+  correlation surviving the filter is what legitimately costs degrees of
+  freedom; AR order by itself does not.
+
+## Bug Fixes
+
+* `robust_psi` now has an effect. It was previously unreachable: `robust`
+  defaulted to `FALSE` rather than `NULL`, so `robust_options$type` was always
+  claimed before `robust_psi` was consulted. `robust`'s default is now `NULL`,
+  which also makes "unspecified" distinguishable from "explicitly off".
+* An explicit `robust = FALSE` is no longer silently overridden by
+  `robust_options = list(type = "huber")`; the combination is now an error.
+* Supplying `cfg` alongside other configuration arguments is now an error
+  instead of silently discarding them. Previously `cor_struct = "ar2"` with a
+  `cfg` naming `"iid"` ran IID without warning.
+* AR shorthands (`cor_struct`, `cor_iter`, `cor_global`, `ar1_exact_first`,
+  `ar_p`, `ar_voxelwise`) that disagree with the corresponding `ar_options`
+  entry now error rather than being silently dropped. Shorthands that agree
+  are still accepted.
+* `engine` now warns about the execution arguments it ignores (`strategy`,
+  `nchunks`, `use_fast_path`, `progress`, `parallel_voxels`,
+  `parallel_chunks`), which were previously accepted and silently discarded.
+* `compute_sandwich_variance()` computed its meat matrix as
+  `X' diag(e^4) X` instead of `X' diag(e^2) X`, giving standard errors about
+  3.5x too large. Both sandwich helpers are now checked against
+  `sandwich::vcovHC()`.
+
+## Performance
+
+* Voxelwise AR fitting no longer recomputes the run-level design projection
+  for every voxel. `.fast_preproject()` performs an `n x n` solve and was
+  being called once per voxel on a design that does not vary by voxel;
+  hoisting it gives roughly a 1.7x speedup on the voxelwise AR path
+  (4.95s to 2.98s for 2000 voxels at 300 timepoints).
+
+## Documentation
+
+* `ar_voxelwise` was documented as overriding `ar_options$voxelwise`. It never
+  did — the options list took precedence — and disagreement is now an error.
+* `use_fast_path` was documented as defaulting to `FALSE` in the runwise and
+  chunkwise fitters; it defaults to `TRUE`.
+* Corrected claims that sandwich variance estimation is applied automatically.
+  It is not used by any `fmri_lm()` fitting path; the robust path reports a
+  model-based weighted-least-squares variance. The accompanying degrees-of-
+  freedom formula was also wrong and has been rewritten.
+
+## Changes
+
+* `fmriAR` is now declared with a minimum version (`>= 0.3.3`) and listed in
+  `Remotes:`; it previously had neither.
+
 ## New Features
 
 * `write_results()` now exports statistical maps as NIfTI volumes via

--- a/R/effective_df.R
+++ b/R/effective_df.R
@@ -1,90 +1,135 @@
 #' Calculate Effective Degrees of Freedom
 #'
-#' Calculates effective degrees of freedom for robust regression and/or
-#' autoregressive models. This adjustment accounts for the loss of efficiency
-#' when using robust estimators or AR error structures.
+#' Residual degrees of freedom for a fit, adjusted for robust down-weighting and
+#' -- when the information is supplied -- for residual correlation that survives
+#' prewhitening.
 #'
 #' @param n Integer. Number of observations.
 #' @param p Integer. Number of parameters.
 #' @param robust_weights Numeric vector of robust weights (NULL if not robust).
-#' @param ar_order Integer. Order of AR model (0 if no AR).
-#' @param method Character. Method for DF adjustment ("satterthwaite", "simple").
+#' @param ar_order Integer. Order of the AR model, or 0. Retained for backward
+#'   compatibility and for reporting; see Details for why it does not by itself
+#'   reduce the degrees of freedom.
+#' @param method Character. `"residual"` (default) uses `n - p`.
+#'   `"satterthwaite"` computes the Satterthwaite approximation and requires
+#'   both `X` and `resid_cov`. `"simple"` is accepted as an alias for
+#'   `"residual"`.
+#' @param X Numeric matrix. The design actually fitted (already whitened, if
+#'   whitening was applied). Required for `method = "satterthwaite"`.
+#' @param resid_cov Numeric matrix. Correlation (or covariance) of the errors of
+#'   the model as fitted -- that is, *after* any whitening. Required for
+#'   `method = "satterthwaite"`. Supply the identity, or omit, when whitening is
+#'   believed exact.
 #'
-#' @return Numeric. Adjusted degrees of freedom.
+#' @return Numeric. Effective residual degrees of freedom, at least 1.
 #'
 #' @details
-#' For robust regression, the effective DF is reduced based on the 
-#' downweighting of outliers. For AR models, DF is reduced based on
-#' the autocorrelation structure.
+#' Write \eqn{R = I - X(X'X)^{-1}X'} for the residual-forming matrix of the model
+#' as fitted, and \eqn{V} for the correlation of that model's errors. Then
+#' \eqn{e'e} is a quadratic form whose Satterthwaite degrees of freedom are
+#' \deqn{\nu = \mathrm{tr}(RV)^2 / \mathrm{tr}(RVRV).}
 #'
-#' The Satterthwaite approximation provides a more accurate adjustment
-#' but requires additional computation.
+#' When whitening succeeds, \eqn{V = I} and this reduces exactly to
+#' \eqn{\mathrm{rank}(R) = n - p}. That is why `ar_order` alone does not reduce
+#' the degrees of freedom: fmrireg's AR path *whitens* the data and then fits by
+#' ordinary least squares, so if the filter is adequate the whitened residuals
+#' already carry \eqn{n - p} degrees of freedom, and reducing them again would
+#' double-count a correction that has already been applied.
+#'
+#' Any shortfall comes from the filter being imperfect, not from the AR order,
+#' and it is captured by passing the post-whitening `resid_cov` and using
+#' `method = "satterthwaite"`.
+#'
+#' Robust down-weighting is handled separately and multiplicatively, by
+#' \eqn{\sum_i w_i / n}.
+#'
+#' @section History:
+#' Before 2026-08-07 this function multiplied the residual degrees of freedom by
+#' \eqn{1 / (1 + 2\sum_k (1 - k/n))} whenever `ar_order > 0`. That factor is the
+#' variance inflation one would obtain if *every* autocorrelation equalled 1, it
+#' never depended on the fitted AR coefficients, and it was applied on top of
+#' whitening. At n = 200, p = 12, AR(1) it returned 62.9 regardless of the true
+#' autocorrelation, where a coefficient-aware calculation spans roughly 170 to 10
+#' as phi runs from 0.05 to 0.9. The result was conservative -- it cost power
+#' rather than inflating false positives -- but it had no basis, and
+#' `method = "satterthwaite"` was a verbatim duplicate of `method = "simple"`.
 #'
 #' @keywords internal
 #' @noRd
-calculate_effective_df <- function(n, p, robust_weights = NULL, 
-                                   ar_order = 0, method = c("simple", "satterthwaite")) {
+calculate_effective_df <- function(n, p, robust_weights = NULL,
+                                   ar_order = 0,
+                                   method = c("residual", "satterthwaite", "simple"),
+                                   X = NULL, resid_cov = NULL) {
   method <- match.arg(method)
-  
-  # Base degrees of freedom
-  df_base <- n - p
-  
-  # Adjustment for robust regression
+  if (identical(method, "simple")) method <- "residual"
+
+  n <- as.numeric(n)
+  p <- as.numeric(p)
+  if (!is.finite(n) || !is.finite(p) || n <= p) {
+    return(1)
+  }
+
+  df_base <- if (identical(method, "satterthwaite")) {
+    if (is.null(X) || is.null(resid_cov)) {
+      stop("method = 'satterthwaite' requires both `X` and `resid_cov`.",
+           call. = FALSE)
+    }
+    .satterthwaite_df(X, resid_cov)
+  } else {
+    n - p
+  }
+
   df_robust_adjust <- 1
   if (!is.null(robust_weights)) {
-    # Effective sample size based on weights
-    # Weights close to 0 indicate outliers that don't contribute
-    eff_n <- sum(robust_weights)
-    df_robust_adjust <- eff_n / n
-  }
-  
-  # Adjustment for AR models
-  df_ar_adjust <- 1
-  if (ar_order > 0) {
-    # With only AR order (no coefficients), use a conservative
-    # correlation-inflation approximation for effective sample size.
-    # This avoids the near-no-op behavior of (n - ar_order) / n.
-    if (method == "simple") {
-      k <- seq_len(ar_order)
-      denom <- 1 + 2 * sum(1 - k / n)
-      df_ar_adjust <- 1 / max(denom, 1)
-    } else {
-      # Satterthwaite-style adjustment would go here
-      # For now, match the conservative simple method.
-      k <- seq_len(ar_order)
-      denom <- 1 + 2 * sum(1 - k / n)
-      df_ar_adjust <- 1 / max(denom, 1)
+    w <- robust_weights[is.finite(robust_weights)]
+    if (length(w)) {
+      # Down-weighting every observation to zero leaves no effective data, so the
+      # adjustment is 0 and the floor below takes over.
+      df_robust_adjust <- sum(w) / length(w)
     }
   }
-  
-  # Combined effective DF
-  df_effective <- df_base * df_robust_adjust * df_ar_adjust
-  
-  # Ensure positive
-  max(df_effective, 1)
+
+  max(df_base * df_robust_adjust, 1)
 }
 
-#' Calculate Sandwich Variance Estimator
+#' Satterthwaite degrees of freedom for a residual sum of squares
 #'
-#' Computes the sandwich (robust) variance estimator for regression
-#' coefficients. This is useful when model assumptions are violated.
-#'
-#' @param X Design matrix.
-#' @param residuals Vector of residuals.
-#' @param XtXinv Inverse of X'X (can be weighted).
-#' @param weights Optional weights (for robust regression).
-#'
-#' @return Matrix. Sandwich variance-covariance matrix.
-#'
-#' @details
-#' The sandwich estimator is computed as:
-#' \deqn{V = (X'X)^{-1} X' diag(e^2) X (X'X)^{-1}}
-#' 
-#' where e are the residuals. This provides valid standard errors
-#' even under heteroscedasticity.
+#' `tr(RV)^2 / tr(RVRV)` with `R = I - X(X'X)^-1 X'`. Computed without forming
+#' `R` explicitly: with `H = X(X'X)^-1X'`, `tr(RV) = tr(V) - tr(HV)` and
+#' `tr(RVRV) = tr(VV) - 2 tr(HVV) + tr(HVHV)`, each of which needs only `n x p`
+#' and `p x p` products.
 #'
 #' @keywords internal
 #' @noRd
+.satterthwaite_df <- function(X, V) {
+  X <- as.matrix(X)
+  n <- nrow(X)
+  if (is.null(dim(V))) V <- diag(as.numeric(V), n)
+  V <- as.matrix(V)
+  stopifnot(nrow(V) == n, ncol(V) == n)
+
+  XtX <- crossprod(X)
+  XtXinv <- tryCatch(solve(XtX), error = function(e) {
+    sv <- svd(XtX)
+    keep <- sv$d > max(sv$d) * .Machine$double.eps^0.5
+    sv$v[, keep, drop = FALSE] %*% ((1 / sv$d[keep]) * t(sv$u[, keep, drop = FALSE]))
+  })
+
+  A  <- X %*% XtXinv          # n x p; H = A X'
+  VX <- V %*% X               # n x p
+  B  <- crossprod(X, VX)      # p x p; X' V X
+
+  # tr(RV)   = tr(V) - tr(HV)
+  # tr(RVRV) = tr(VV) - 2 tr(HVV) + tr(HVHV),  using tr(VHV) = tr(HVV)
+  tr_RV   <- sum(diag(V)) - sum(A * VX)
+  tr_HVV  <- sum(A * (V %*% VX))
+  BG      <- B %*% XtXinv
+  tr_RVRV <- sum(V * t(V)) - 2 * tr_HVV + sum(BG * t(BG))
+
+  if (!is.finite(tr_RV) || !is.finite(tr_RVRV) || tr_RVRV <= 0) return(1)
+  max(tr_RV^2 / tr_RVRV, 1)
+}
+
 calculate_sandwich_variance <- function(X, residuals, XtXinv, weights = NULL) {
   n <- nrow(X)
   p <- ncol(X)

--- a/R/fmri_lm_chunkwise.R
+++ b/R/fmri_lm_chunkwise.R
@@ -13,7 +13,7 @@
 #' @param nchunks The number of chunks to divide the dataset into.
 #' @param cfg An \code{fmri_lm_config} object containing all fitting options.
 #' @param verbose Logical. Whether to display progress messages (default is \code{FALSE}).
-#' @param use_fast_path Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.
+#' @param use_fast_path Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{TRUE}.
 #' @param progress Logical. Display a progress bar for chunk processing. Default is \code{FALSE}.
 #' @param parallel_chunks Logical. If \code{TRUE}, process chunks with
 #'   \code{future.apply::future_lapply()} using the active future plan.

--- a/R/fmri_lm_contrasts.R
+++ b/R/fmri_lm_contrasts.R
@@ -272,13 +272,11 @@ compute_sandwich_variance <- function(X, residuals, type = "HC1") {
   if (ncol(residuals) > 1) {
     meat <- matrix(0, p, p)
     for (v in 1:ncol(residuals)) {
-      Xe <- X * e2[, v]
-      meat <- meat + crossprod(Xe)
+      meat <- meat + crossprod(X, X * e2[, v])
     }
     meat <- meat / ncol(residuals)
   } else {
-    Xe <- X * as.vector(e2)
-    meat <- crossprod(Xe)
+    meat <- crossprod(X, X * as.vector(e2))
   }
   
   # Sandwich

--- a/R/fmri_lm_runwise.R
+++ b/R/fmri_lm_runwise.R
@@ -14,7 +14,7 @@ NULL
 #' @param contrast_objects The list of full contrast objects.
 #' @param cfg An \code{fmri_lm_config} object containing all fitting options.
 #' @param verbose Logical. Whether to display progress messages (default is \code{FALSE}).
-#' @param use_fast_path Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.
+#' @param use_fast_path Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{TRUE}.
 #' @param progress Logical. Display a progress bar for run processing. Default is \code{FALSE}.
 #' @param phi_fixed Optional fixed AR parameters.
 #' @param sigma_fixed Optional fixed robust scale estimate.
@@ -380,6 +380,12 @@ runwise_lm_voxelwise <- function(chunks, model, cfg, simple_conlist_weights, fco
     n_voxels <- ncol(Y_run)
     n_timepoints <- nrow(Y_run)
     p <- ncol(X_run)
+
+    # X_run does not vary by voxel, so its projection is computed once here
+    # rather than inside the per-voxel loops. .fast_preproject() is not cheap --
+    # besides qr(X) it forms qr.coef(qr_decomp, diag(n)), an n x n solve -- and
+    # it was previously recomputed for every voxel and discarded.
+    proj_run_unwhitened <- .fast_preproject(X_run)
     
     # Storage for voxel-wise results
     betas_voxelwise <- matrix(NA_real_, p, n_voxels)
@@ -408,8 +414,8 @@ runwise_lm_voxelwise <- function(chunks, model, cfg, simple_conlist_weights, fco
         
         # Initial OLS fit
         Y_voxel_mat <- matrix(y_voxel, ncol = 1)
-        proj_voxel <- .fast_preproject(X_run)
-        glm_ctx_voxel <- glm_context(X = X_run, Y = Y_voxel_mat, proj = proj_voxel)
+        glm_ctx_voxel <- glm_context(X = X_run, Y = Y_voxel_mat,
+                                     proj = proj_run_unwhitened)
         initial_fit <- solve_glm_core(glm_ctx_voxel)
         
         # Estimate voxel-specific AR parameters
@@ -482,8 +488,8 @@ runwise_lm_voxelwise <- function(chunks, model, cfg, simple_conlist_weights, fco
         
         # Initial OLS fit
         Y_voxel_mat <- matrix(y_voxel, ncol = 1)
-        proj_voxel <- .fast_preproject(X_run)
-        glm_ctx_voxel <- glm_context(X = X_run, Y = Y_voxel_mat, proj = proj_voxel)
+        glm_ctx_voxel <- glm_context(X = X_run, Y = Y_voxel_mat,
+                                     proj = proj_run_unwhitened)
         initial_fit <- solve_glm_core(glm_ctx_voxel)
         
         # Estimate voxel-specific AR parameters

--- a/R/fmrilm.R
+++ b/R/fmrilm.R
@@ -257,22 +257,36 @@ fmri_lm <- function(formula, ...) {
                                               robust_max_iter = NULL,
                                               robust_scale_scope = NULL,
                                               engine_robust_options = NULL) {
-  robust_type <- if (is.logical(robust)) {
-    if (robust) "huber" else FALSE
-  } else {
-    robust
-  }
-
   robust_options <- robust_options %||% list()
   if (!is.null(engine_robust_options)) {
     robust_options <- utils::modifyList(robust_options, engine_robust_options)
   }
-  if (!is.null(robust_type) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_type
+
+  # `type` can be requested three ways. Previously the first non-NULL of
+  # (robust, robust_psi, robust_options$type) won by position, which made
+  # `robust_psi` unreachable (robust defaults to NULL only since this fix; it
+  # used to default to FALSE, so its branch always fired first) and let an
+  # explicit `robust = FALSE` be overridden by `robust_options$type`. Requests
+  # are now collected and a genuine disagreement is an error.
+  canon <- function(x) {
+    if (is.logical(x)) if (isTRUE(x)) "huber" else "none" else as.character(x)
   }
-  if (!is.null(robust_psi) && !("type" %in% names(robust_options))) {
-    robust_options$type <- robust_psi
+  requested <- c(
+    if (!is.null(robust))                  stats::setNames(canon(robust), "robust"),
+    if (!is.null(robust_psi))              stats::setNames(canon(robust_psi), "robust_psi"),
+    if ("type" %in% names(robust_options)) stats::setNames(canon(robust_options$type), "robust_options$type")
+  )
+  if (length(unique(requested)) > 1L) {
+    stop("Conflicting robust settings: ",
+         paste(sprintf("`%s` = %s", names(requested), sQuote(requested)), collapse = ", "),
+         ". Supply only one.", call. = FALSE)
   }
+  if (length(requested)) {
+    robust_options$type <- if (requested[[1L]] == "none") FALSE else requested[[1L]]
+  } else {
+    robust_options$type <- FALSE
+  }
+
   if (!is.null(robust_max_iter) && !("max_iter" %in% names(robust_options))) {
     robust_options$max_iter <- robust_max_iter
   }
@@ -286,7 +300,7 @@ fmri_lm <- function(formula, ...) {
 #' @keywords internal
 #' @noRd
 .fmri_lm_normalize_ar_options <- function(ar_options = NULL,
-                                          ar_voxelwise = FALSE,
+                                          ar_voxelwise = NULL,
                                           cor_struct = NULL,
                                           cor_iter = NULL,
                                           cor_global = NULL,
@@ -298,23 +312,35 @@ fmri_lm <- function(formula, ...) {
     ar_options <- utils::modifyList(ar_options, engine_ar_options)
   }
 
-  if (!is.null(cor_struct) && !("struct" %in% names(ar_options))) {
-    ar_options$struct <- cor_struct
-  }
-  if (!is.null(cor_iter) && !("iter_gls" %in% names(ar_options))) {
-    ar_options$iter_gls <- cor_iter
-  }
-  if (!is.null(cor_global) && !("global" %in% names(ar_options))) {
-    ar_options$global <- cor_global
-  }
-  if (!is.null(ar1_exact_first) && !("exact_first" %in% names(ar_options))) {
-    ar_options$exact_first <- ar1_exact_first
-  }
-  if (!is.null(ar_p) && !("p" %in% names(ar_options))) {
-    ar_options$p <- ar_p
+  # Each shorthand is an alias for one `ar_options` key. Previously the list won
+  # by position and the shorthand was dropped without a word -- which also made
+  # the documented precedence for `ar_voxelwise` ("overrides ar_options$voxelwise")
+  # exactly backwards. A shorthand that agrees with the list is accepted; one that
+  # disagrees is an error rather than a silent choice.
+  aliases <- list(
+    cor_struct      = list(key = "struct",      value = cor_struct),
+    cor_iter        = list(key = "iter_gls",    value = cor_iter),
+    cor_global      = list(key = "global",      value = cor_global),
+    ar1_exact_first = list(key = "exact_first", value = ar1_exact_first),
+    ar_p            = list(key = "p",           value = ar_p),
+    ar_voxelwise    = list(key = "voxelwise",   value = ar_voxelwise)
+  )
+  for (nm in names(aliases)) {
+    a <- aliases[[nm]]
+    if (is.null(a$value)) next
+    if (a$key %in% names(ar_options)) {
+      if (!isTRUE(all.equal(ar_options[[a$key]], a$value))) {
+        stop(sprintf(
+          "Conflicting AR settings: `%s` = %s and `ar_options$%s` = %s. Supply only one.",
+          nm, sQuote(format(a$value)), a$key, sQuote(format(ar_options[[a$key]]))),
+          call. = FALSE)
+      }
+    } else {
+      ar_options[[a$key]] <- a$value
+    }
   }
   if (!("voxelwise" %in% names(ar_options))) {
-    ar_options$voxelwise <- ar_voxelwise
+    ar_options$voxelwise <- FALSE
   }
 
   if (!is.null(ar_options$order) && is.null(ar_options$struct)) {
@@ -377,7 +403,7 @@ fmri_lm <- function(formula, ...) {
                                   robust_max_iter = NULL,
                                   robust_scale_scope = NULL,
                                   ar_options = NULL,
-                                  ar_voxelwise = FALSE,
+                                  ar_voxelwise = NULL,
                                   cor_struct = NULL,
                                   cor_iter = NULL,
                                   cor_global = NULL,
@@ -390,6 +416,32 @@ fmri_lm <- function(formula, ...) {
                                   engine_ar_options = NULL,
                                   engine_robust_options = NULL,
                                   engine_cfg = NULL) {
+  # A supplied `cfg` used to replace the config wholesale, silently discarding
+  # every other configuration argument -- so `cor_struct = "ar2"` alongside a cfg
+  # naming "iid" ran iid without a word. Refuse the ambiguity instead.
+  if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
+    supplied <- c(
+      robust = !is.null(robust), robust_options = !is.null(robust_options),
+      robust_psi = !is.null(robust_psi), robust_max_iter = !is.null(robust_max_iter),
+      robust_scale_scope = !is.null(robust_scale_scope),
+      ar_options = !is.null(ar_options), ar_voxelwise = !is.null(ar_voxelwise),
+      cor_struct = !is.null(cor_struct), cor_iter = !is.null(cor_iter),
+      cor_global = !is.null(cor_global), ar1_exact_first = !is.null(ar1_exact_first),
+      ar_p = !is.null(ar_p),
+      volume_weights_options = !is.null(volume_weights_options),
+      soft_subspace_options = !is.null(soft_subspace_options),
+      volume_weights = !is.null(volume_weights),
+      nuisance_projection = !is.null(nuisance_projection)
+    )
+    if (any(supplied)) {
+      stop("`cfg` cannot be combined with other configuration arguments. ",
+           "Also supplied: ", paste0("`", names(supplied)[supplied], "`", collapse = ", "),
+           ". Put every setting in `cfg`, or drop `cfg` and use the individual arguments.",
+           call. = FALSE)
+    }
+    return(engine_cfg)
+  }
+
   robust_options <- .fmri_lm_normalize_robust_options(
     robust = robust,
     robust_options = robust_options,
@@ -417,23 +469,12 @@ fmri_lm <- function(formula, ...) {
     nuisance_projection = nuisance_projection
   )
 
-  cfg <- if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    engine_cfg
-  } else {
-    fmri_lm_control(
-      robust_options = robust_options,
-      ar_options = ar_options,
-      volume_weights_options = preprocessing$volume_weights_options,
-      soft_subspace_options = preprocessing$soft_subspace_options
-    )
-  }
-
-  if (!is.null(engine_cfg) && inherits(engine_cfg, "fmri_lm_config")) {
-    cfg$robust <- engine_cfg$robust
-    cfg$ar <- utils::modifyList(cfg$ar, engine_cfg$ar)
-  }
-
-  cfg
+  fmri_lm_control(
+    robust_options = robust_options,
+    ar_options = ar_options,
+    volume_weights_options = preprocessing$volume_weights_options,
+    soft_subspace_options = preprocessing$soft_subspace_options
+  )
 }
 
 #' @keywords internal
@@ -467,6 +508,32 @@ fmri_lm <- function(formula, ...) {
     stop(sprintf("Unknown engine '%s'.", engine), call. = FALSE)
   }
   spec
+}
+
+#' @keywords internal
+#' @noRd
+#' Warn about execution arguments an engine silently ignores
+#'
+#' `.fmri_lm_dispatch_engine()` is called without `strategy`, `nchunks`,
+#' `use_fast_path`, `progress`, or the `parallel_*` flags, so supplying them
+#' alongside `engine` had no effect and said nothing. Detection is via
+#' `match.call()` rather than `missing()` because these arguments have non-NULL
+#' defaults and some are reassigned by `match.arg()` before dispatch.
+#'
+#' @keywords internal
+#' @noRd
+.fmri_lm_warn_engine_ignores <- function(call, engine) {
+  ignored <- c("strategy", "nchunks", "use_fast_path", "progress",
+               "parallel_voxels", "parallel_chunks")
+  supplied <- intersect(ignored, names(call)[-1L])
+  if (length(supplied)) {
+    warning(sprintf(
+      "engine = \"%s\" ignores %s; %s control the built-in fitter only.",
+      engine, paste0("`", supplied, "`", collapse = ", "),
+      if (length(supplied) == 1L) "it controls" else "they control"),
+      call. = FALSE)
+  }
+  invisible(supplied)
 }
 
 #' @keywords internal
@@ -521,7 +588,8 @@ fmri_lm <- function(formula, ...) {
 #'   \code{FALSE} selects the formula/lm reference engine (no robust or full
 #'   preprocessing support); it is retained mainly as a parity oracle.
 #' @param progress Logical. Whether to display a progress bar during model fitting. Default is \code{FALSE}.
-#' @param ar_voxelwise Logical. Estimate AR parameters voxel-wise (overrides \code{ar_options$voxelwise}).
+#' @param ar_voxelwise Logical. Estimate AR parameters voxel-wise. Shorthand for
+#'   \code{ar_options$voxelwise}; supplying both with different values is an error.
 #' @param parallel_voxels Logical. Parallelize across voxels where supported;
 #'   this does not control chunkwise execution.
 #' @param parallel_chunks Logical. For \code{strategy = "chunkwise"}, process
@@ -663,10 +731,10 @@ fmri_lm <- function(formula, ...) {
 #' }
 #' 
 fmri_lm.formula <- function(formula, block, baseline_model = NULL, dataset, durations = 0, drop_empty = TRUE,
-                         robust = FALSE, robust_options = NULL, ar_options = NULL,
+                         robust = NULL, robust_options = NULL, ar_options = NULL,
                          volume_weights_options = NULL, soft_subspace_options = NULL,
                          strategy = c("runwise", "chunkwise"), nchunks = 10, use_fast_path = TRUE, progress = FALSE,
-                         ar_voxelwise = FALSE,
+                         ar_voxelwise = NULL,
                          parallel_voxels = FALSE,
                     # Individual AR parameters for backward compatibility
                     cor_struct = NULL, cor_iter = NULL, cor_global = NULL,
@@ -694,10 +762,11 @@ fmri_lm.formula <- function(formula, block, baseline_model = NULL, dataset, dura
   assert_that(inherits(dataset, "fmri_dataset"), msg = "'dataset' must be an 'fmri_dataset'")
   assert_that(is.numeric(durations), msg = "'durations' must be numeric")
   assert_that(is.logical(drop_empty), msg = "'drop_empty' must be logical")
-  assert_that(is.logical(robust) || robust %in% c("huber", "bisquare"), 
-              msg = "'robust' must be logical or one of 'huber', 'bisquare'")
+  assert_that(is.null(robust) || is.logical(robust) || robust %in% c("huber", "bisquare"),
+              msg = "'robust' must be NULL, logical, or one of 'huber', 'bisquare'")
   assert_that(is.logical(use_fast_path), msg = "'use_fast_path' must be logical")
-  assert_that(is.logical(ar_voxelwise), msg = "'ar_voxelwise' must be logical")
+  assert_that(is.null(ar_voxelwise) || is.logical(ar_voxelwise),
+              msg = "'ar_voxelwise' must be NULL or logical")
   assert_that(
     is.logical(parallel_chunks) && length(parallel_chunks) == 1L && !is.na(parallel_chunks),
     msg = "'parallel_chunks' must be TRUE or FALSE"
@@ -732,6 +801,7 @@ fmri_lm.formula <- function(formula, block, baseline_model = NULL, dataset, dura
   model <- create_fmri_model(formula, block, baseline_model, dataset, durations = durations, drop_empty = drop_empty)
 
   if (!is.null(engine)) {
+    .fmri_lm_warn_engine_ignores(match.call(), engine)
     return(.fmri_lm_dispatch_engine(
       model = model,
       dataset = dataset,
@@ -755,12 +825,12 @@ fmri_lm.formula <- function(formula, block, baseline_model = NULL, dataset, dura
 #' @rdname fmri_lm
 #' @export
 fmri_lm.fmri_model <- function(formula, dataset = NULL,
-                               robust = FALSE, robust_options = NULL,
+                               robust = NULL, robust_options = NULL,
                                ar_options = NULL,
                                volume_weights_options = NULL, soft_subspace_options = NULL,
                                strategy = c("runwise", "chunkwise"), nchunks = 10,
                                use_fast_path = TRUE, progress = FALSE,
-                               ar_voxelwise = FALSE, parallel_voxels = FALSE,
+                               ar_voxelwise = NULL, parallel_voxels = FALSE,
                                cor_struct = NULL, cor_iter = NULL,
                                cor_global = NULL, ar1_exact_first = NULL,
                                ar_p = NULL,
@@ -812,6 +882,7 @@ fmri_lm.fmri_model <- function(formula, dataset = NULL,
   )
 
   if (!is.null(engine)) {
+    .fmri_lm_warn_engine_ignores(match.call(), engine)
     return(.fmri_lm_dispatch_engine(
       model = formula,
       dataset = dataset,

--- a/R/sandwich_variance_doc.R
+++ b/R/sandwich_variance_doc.R
@@ -20,19 +20,29 @@
 #' \deqn{V_{sandwich} = (X'WX)^{-1} X'W \Omega WX (X'WX)^{-1}}
 #'
 #' @section Usage in fmrireg:
-#' Sandwich variance estimation is automatically used when:
-#' - Robust regression is enabled (using M-estimators)
-#' - AR modeling is combined with robust regression
-#' - Heteroscedasticity is suspected in the residuals
+#' Sandwich variance estimation is \strong{not} currently applied by
+#' \code{\link{fmri_lm}}. The helpers documented here are available for direct
+#' use, but no fitting path calls them: the robust path reports a model-based
+#' weighted-least-squares variance,
+#' \eqn{\hat\sigma^2_{robust} \, \mathrm{diag}((X'WX)^{-1})}, not a sandwich.
+#'
+#' Applying a sandwich to the robust path correctly would require the
+#' M-estimator influence-function form, whose weights and influence matrix are
+#' voxel-dependent, rather than the ordinary-least-squares expression above.
 #'
 #' @section Effective Degrees of Freedom:
-#' When using robust regression and/or AR models, the effective degrees of
-#' freedom are adjusted to account for:
-#' - Downweighting of outliers in robust regression
-#' - Loss of degrees of freedom due to AR parameter estimation
-#' 
-#' The adjustment formula is:
-#' \deqn{df_{effective} = df_{base} \times \frac{\sum w_i}{n} \times \frac{n - p_{AR}}{n}}
+#' Robust down-weighting reduces the residual degrees of freedom multiplicatively:
+#' \deqn{df_{effective} = (n - p) \times \frac{\sum_i w_i}{n}.}
+#'
+#' AR order does \strong{not} enter this formula. fmrireg whitens the data and
+#' then fits by ordinary least squares, so when the filter is adequate the
+#' whitened residuals already carry \eqn{n - p} degrees of freedom and reducing
+#' them again would double-count. A filter that leaves residual correlation
+#' behind does cost degrees of freedom, and that shortfall is measured by the
+#' Satterthwaite approximation
+#' \deqn{\nu = \mathrm{tr}(RV)^2 / \mathrm{tr}(RVRV)}
+#' applied to the post-whitening covariance \eqn{V}, which reduces exactly to
+#' \eqn{n - p} when \eqn{V = I}.
 #'
 #' @examples
 #' \dontrun{

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ fit  <- fmri_lm(fmod, dataset = dset)
   supports categorical events, continuous modulators, and multi-basis expansions.
 - **Contrast system** -- Flexible contrasts via formulas, including pairwise,
   polynomial, and F-contrasts.
-- **Robust estimation** -- OLS, iteratively reweighted least squares (IWLS),
-  and sandwich variance estimators.
+- **Robust estimation** -- OLS and iteratively reweighted least squares (IWLS)
+  with Huber and Tukey bisquare psi functions.
 - **AR correction** -- Autoregressive noise modeling via the
   [fmriAR](https://github.com/bbuchsbaum/fmriAR) package.
 - **Performance** -- C++ solvers (Rcpp/RcppArmadillo) with optional

--- a/man/chunkwise_lm.fmri_dataset.Rd
+++ b/man/chunkwise_lm.fmri_dataset.Rd
@@ -32,7 +32,7 @@
 
 \item{verbose}{Logical. Whether to display progress messages (default is \code{FALSE}).}
 
-\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.}
+\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{TRUE}.}
 
 \item{progress}{Logical. Display a progress bar for chunk processing. Default is \code{FALSE}.}
 

--- a/man/fmri_lm.Rd
+++ b/man/fmri_lm.Rd
@@ -15,7 +15,7 @@ fmri_lm(formula, ...)
   dataset,
   durations = 0,
   drop_empty = TRUE,
-  robust = FALSE,
+  robust = NULL,
   robust_options = NULL,
   ar_options = NULL,
   volume_weights_options = NULL,
@@ -24,7 +24,7 @@ fmri_lm(formula, ...)
   nchunks = 10,
   use_fast_path = TRUE,
   progress = FALSE,
-  ar_voxelwise = FALSE,
+  ar_voxelwise = NULL,
   parallel_voxels = FALSE,
   cor_struct = NULL,
   cor_iter = NULL,
@@ -43,7 +43,7 @@ fmri_lm(formula, ...)
 \method{fmri_lm}{fmri_model}(
   formula,
   dataset = NULL,
-  robust = FALSE,
+  robust = NULL,
   robust_options = NULL,
   ar_options = NULL,
   volume_weights_options = NULL,
@@ -52,7 +52,7 @@ fmri_lm(formula, ...)
   nchunks = 10,
   use_fast_path = TRUE,
   progress = FALSE,
-  ar_voxelwise = FALSE,
+  ar_voxelwise = NULL,
   parallel_voxels = FALSE,
   cor_struct = NULL,
   cor_iter = NULL,
@@ -109,7 +109,8 @@ preprocessing support); it is retained mainly as a parity oracle.}
 
 \item{progress}{Logical. Whether to display a progress bar during model fitting. Default is \code{FALSE}.}
 
-\item{ar_voxelwise}{Logical. Estimate AR parameters voxel-wise (overrides \code{ar_options$voxelwise}).}
+\item{ar_voxelwise}{Logical. Estimate AR parameters voxel-wise. Shorthand for
+\code{ar_options$voxelwise}; supplying both with different values is an error.}
 
 \item{parallel_voxels}{Logical. Parallelize across voxels where supported;
 this does not control chunkwise execution.}

--- a/man/runwise_lm_impl.Rd
+++ b/man/runwise_lm_impl.Rd
@@ -28,7 +28,7 @@ runwise_lm_impl(
 
 \item{verbose}{Logical. Whether to display progress messages (default is \code{FALSE}).}
 
-\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{FALSE}.}
+\item{use_fast_path}{Logical. If \code{TRUE}, use matrix-based computation for speed. Default is \code{TRUE}.}
 
 \item{progress}{Logical. Display a progress bar for run processing. Default is \code{FALSE}.}
 

--- a/man/sandwich_variance.Rd
+++ b/man/sandwich_variance.Rd
@@ -28,25 +28,31 @@ For robust regression with weights \eqn{w_i}, the weighted version is:
 
 \section{Usage in fmrireg}{
 
-Sandwich variance estimation is automatically used when:
-\itemize{
-\item Robust regression is enabled (using M-estimators)
-\item AR modeling is combined with robust regression
-\item Heteroscedasticity is suspected in the residuals
-}
+Sandwich variance estimation is \strong{not} currently applied by
+\code{\link{fmri_lm}}. The helpers documented here are available for direct
+use, but no fitting path calls them: the robust path reports a model-based
+weighted-least-squares variance,
+\eqn{\hat\sigma^2_{robust} \, \mathrm{diag}((X'WX)^{-1})}, not a sandwich.
+
+Applying a sandwich to the robust path correctly would require the
+M-estimator influence-function form, whose weights and influence matrix are
+voxel-dependent, rather than the ordinary-least-squares expression above.
 }
 
 \section{Effective Degrees of Freedom}{
 
-When using robust regression and/or AR models, the effective degrees of
-freedom are adjusted to account for:
-\itemize{
-\item Downweighting of outliers in robust regression
-\item Loss of degrees of freedom due to AR parameter estimation
-}
+Robust down-weighting reduces the residual degrees of freedom multiplicatively:
+\deqn{df_{effective} = (n - p) \times \frac{\sum_i w_i}{n}.}
 
-The adjustment formula is:
-\deqn{df_{effective} = df_{base} \times \frac{\sum w_i}{n} \times \frac{n - p_{AR}}{n}}
+AR order does \strong{not} enter this formula. fmrireg whitens the data and
+then fits by ordinary least squares, so when the filter is adequate the
+whitened residuals already carry \eqn{n - p} degrees of freedom and reducing
+them again would double-count. A filter that leaves residual correlation
+behind does cost degrees of freedom, and that shortfall is measured by the
+Satterthwaite approximation
+\deqn{\nu = \mathrm{tr}(RV)^2 / \mathrm{tr}(RVRV)}
+applied to the post-whitening covariance \eqn{V}, which reduces exactly to
+\eqn{n - p} when \eqn{V = I}.
 }
 
 \section{Implementation Notes}{

--- a/tests/testthat/helper-variance.R
+++ b/tests/testthat/helper-variance.R
@@ -1,0 +1,145 @@
+# Substrate for first-level variance validation.
+#
+# Everything here is a self-contained reference implementation: it does not call
+# fmrireg, so it can serve as an independent oracle for the package's variance
+# arithmetic. Noise covariances are returned with unit lag-0 so a caller can
+# scale them freely.
+
+# ---- noise covariance constructors -------------------------------------------
+
+.vt_ar1 <- function(n_t, rho) rho^abs(outer(seq_len(n_t), seq_len(n_t), "-"))
+
+.vt_arma11 <- function(n_t, phi, theta) {
+  h <- seq_len(n_t) - 1L
+  g0 <- (1 + 2 * phi * theta + theta^2) / (1 - phi^2)
+  g1 <- (1 + phi * theta) * (phi + theta) / (1 - phi^2)
+  stats::toeplitz(c(g0, g1 * phi^(h[-1] - 1)) / g0)
+}
+
+# 1/f^alpha noise built from its power spectrum, with a white floor
+.vt_1f <- function(n_t, alpha = 1) {
+  f <- seq(0, 0.5, length.out = n_t)
+  S <- 1 / (pmax(f, 1 / (2 * n_t))^alpha) + 0.5
+  g <- vapply(seq_len(n_t) - 1L, function(h) sum(S * cos(2 * pi * f * h)), numeric(1))
+  stats::toeplitz(g / g[1])
+}
+
+# short-memory AR plus a damped oscillation (physio-like); PSD-projected
+.vt_osc <- function(n_t) {
+  h <- seq_len(n_t) - 1L
+  g <- 0.4^h + 0.35 * cos(2 * pi * h / 12) * exp(-h / 40)
+  S <- stats::toeplitz(g / g[1])
+  e <- eigen(S, symmetric = TRUE)
+  e$values <- pmax(e$values, 1e-8)
+  S <- e$vectors %*% diag(e$values) %*% t(e$vectors)
+  S / S[1, 1]
+}
+
+.vt_regimes <- function(n_t) {
+  list(
+    `AR(1) rho=0.4`    = .vt_ar1(n_t, 0.4),
+    `ARMA(1,1)`        = .vt_arma11(n_t, 0.5, 0.4),
+    `1/f long memory`  = .vt_1f(n_t),
+    `AR+oscillatory`   = .vt_osc(n_t)
+  )
+}
+
+# ---- design construction -----------------------------------------------------
+
+.vt_hrf <- function(t) {
+  ifelse(t < 0, 0, stats::dgamma(t, 6, scale = 1) - (1 / 6) * stats::dgamma(t, 16, scale = 1))
+}
+
+.vt_convolve <- function(onsets, n_t, TR = 2) {
+  s <- numeric(n_t)
+  idx <- pmin(n_t, pmax(1L, round(onsets / TR) + 1L))
+  for (i in idx) s[i] <- s[i] + 1
+  k <- .vt_hrf(seq(0, 30, by = TR))
+  r <- as.numeric(stats::filter(c(s, rep(0, length(k))), k, sides = 1)[seq_len(n_t)])
+  r[is.na(r)] <- 0
+  r
+}
+
+.vt_dct <- function(n_t, cutoff_s, TR = 2) {
+  n <- max(1L, floor(2 * n_t * TR / cutoff_s))
+  vapply(seq_len(n), function(k) {
+    sqrt(2 / n_t) * cos(pi * (2 * seq_len(n_t) - 1) * k / (2 * n_t))
+  }, numeric(n_t))
+}
+
+# type: "er" (rapid randomized event-related) or "block"
+.vt_design <- function(n_t, type = c("er", "block"), n_cond = 2L,
+                       cutoff_s = 128, TR = 2, seed = 1L) {
+  type <- match.arg(type)
+  set.seed(seed)
+  if (type == "er") {
+    onsets <- sort(stats::runif(20 * n_cond, 0, n_t * TR - 20))
+    grp <- rep(seq_len(n_cond), length.out = length(onsets))
+    Xt <- vapply(seq_len(n_cond),
+                 function(g) .vt_convolve(onsets[grp == g], n_t, TR), numeric(n_t))
+  } else {
+    starts <- seq(0, n_t * TR - 60, by = 60)
+    grp <- rep(seq_len(n_cond), length.out = length(starts))
+    Xt <- vapply(seq_len(n_cond), function(g) {
+      on <- unlist(lapply(starts[grp == g], function(s) seq(s, s + 28, by = 2)))
+      .vt_convolve(on, n_t, TR)
+    }, numeric(n_t))
+  }
+  cbind(Xt, 1, .vt_dct(n_t, cutoff_s, TR))
+}
+
+# ---- reduced-space variance oracle -------------------------------------------
+
+# Cov(C beta) = sum_h gamma_h * (L T_h L'), computed per run with no lag product
+# spanning a run boundary. gamma_by_run is a named list keyed by run label.
+.vt_reduced_var <- function(L, gamma_by_run, run_id) {
+  q <- nrow(L)
+  acc <- matrix(0, q, q)
+  for (r in sort(unique(run_id))) {
+    Lr <- L[, run_id == r, drop = FALSE]
+    n <- ncol(Lr)
+    g <- gamma_by_run[[as.character(r)]]
+    H <- min(length(g) - 1L, n - 1L)
+    acc <- acc + g[1] * tcrossprod(Lr)
+    if (H >= 1L) {
+      for (h in seq_len(H)) {
+        A <- Lr[, seq_len(n - h), drop = FALSE] %*% t(Lr[, seq(h + 1L, n), drop = FALSE])
+        acc <- acc + g[h + 1L] * (A + t(A))
+      }
+    }
+  }
+  acc
+}
+
+# mean of the entries of Rm at each lag 0..H
+.vt_lag_mean <- function(Rm, H, d) {
+  vapply(0:H, function(h) mean(Rm[d == h]), numeric(1))
+}
+
+# Residual-forming bias map: E[acvf(resid)] = A %*% gamma_true, A from the design
+# only. Solve A for a debiased autocovariance. Exact when the true covariance is
+# supported within lag H.
+.vt_bias_map <- function(X, H) {
+  n_t <- nrow(X)
+  M <- diag(n_t) - X %*% solve(crossprod(X), t(X))
+  d <- abs(outer(seq_len(n_t), seq_len(n_t), "-"))
+  vapply(0:H, function(h2) {
+    Th <- matrix(0, n_t, n_t)
+    Th[d == h2] <- 1
+    .vt_lag_mean(M %*% Th %*% M, H, d)
+  }, numeric(H + 1L))
+}
+
+# ---- analytic references -----------------------------------------------------
+
+# exact SE of a contrast under OLS with known Sigma:  sqrt(c' P Sigma P' c)
+.vt_true_se <- function(X, Sigma, cvec) {
+  P <- solve(crossprod(X), t(X))
+  L <- matrix(cvec, nrow = 1) %*% P
+  sqrt(drop(L %*% Sigma %*% t(L)))
+}
+
+# classical OLS SE assuming iid errors with variance s2
+.vt_iid_se <- function(X, s2, cvec) {
+  sqrt(drop(s2 * matrix(cvec, nrow = 1) %*% solve(crossprod(X)) %*% matrix(cvec, ncol = 1)))
+}

--- a/tests/testthat/test-effective-df-correctness.R
+++ b/tests/testthat/test-effective-df-correctness.R
@@ -1,0 +1,231 @@
+# Correctness of calculate_effective_df().
+#
+# The previous implementation multiplied n - p by 1/(1 + 2*sum(1 - k/n)) whenever
+# ar_order > 0. That factor assumes every autocorrelation equals 1, never depends
+# on the fitted AR coefficients, and was applied on top of whitening. These tests
+# pin the corrected behaviour against closed forms, an independent brute-force
+# implementation, and -- the gate that actually matters -- empirical calibration
+# of the resulting t statistics.
+
+.edf  <- function(...) fmrireg:::calculate_effective_df(...)
+.sdf  <- function(...) fmrireg:::.satterthwaite_df(...)
+
+# Brute-force reference: form R explicitly and take the traces directly.
+.sdf_ref <- function(X, V) {
+  n <- nrow(X)
+  R <- diag(n) - X %*% solve(crossprod(X), t(X))
+  RV <- R %*% V
+  sum(diag(RV))^2 / sum(diag(RV %*% RV))
+}
+
+# ------------------------------------------------------------- basic contract --
+
+test_that("residual method returns n - p and ignores AR order", {
+  # AR whitening happens before the fit, so the whitened residuals already carry
+  # n - p degrees of freedom; reducing them again double-counts.
+  expect_equal(.edf(200, 12), 188)
+  expect_equal(.edf(200, 12, ar_order = 1), 188)
+  expect_equal(.edf(200, 12, ar_order = 4), 188)
+  expect_equal(.edf(300, 30, ar_order = 2), 270)
+})
+
+test_that("the old phi-blind value is no longer produced", {
+  # regression guard: the previous implementation returned 62.9 here for every phi
+  expect_false(isTRUE(all.equal(.edf(200, 12, ar_order = 1), 62.9, tolerance = 1e-2)))
+  expect_false(isTRUE(all.equal(.edf(200, 12, ar_order = 2), 37.8, tolerance = 1e-2)))
+})
+
+test_that("'simple' is accepted as an alias for 'residual'", {
+  expect_equal(.edf(200, 12, method = "simple"),
+               .edf(200, 12, method = "residual"))
+  expect_equal(.edf(200, 12, ar_order = 3, method = "simple"), 188)
+})
+
+test_that("satterthwaite is no longer a duplicate of the simple method", {
+  # it used to be a verbatim copy; it now needs real inputs and refuses without them
+  expect_error(.edf(200, 12, method = "satterthwaite"), "requires both")
+  expect_error(.edf(200, 12, method = "satterthwaite", X = matrix(1, 200, 2)),
+               "requires both")
+})
+
+test_that("degenerate inputs return at least 1", {
+  expect_equal(.edf(5, 5), 1)
+  expect_equal(.edf(3, 10), 1)
+  expect_gte(.edf(20, 2, robust_weights = rep(1e-8, 20)), 1)
+})
+
+# --------------------------------------------------------- satterthwaite core --
+
+test_that("Satterthwaite reduces exactly to n - p when errors are uncorrelated", {
+  for (n in c(60L, 150L)) {
+    for (p in c(3L, 10L)) {
+      X <- cbind(1, matrix(rnorm(n * (p - 1)), n, p - 1))
+      expect_equal(.sdf(X, diag(n)), n - p, tolerance = 1e-8,
+                   info = sprintf("n=%d p=%d", n, p))
+      expect_equal(.edf(n, p, method = "satterthwaite", X = X, resid_cov = diag(n)),
+                   n - p, tolerance = 1e-8)
+    }
+  }
+})
+
+test_that("Satterthwaite matches a brute-force trace computation", {
+  set.seed(11)
+  n <- 120L
+  X <- .vt_design(n, "er")
+  for (nm in names(.vt_regimes(n))) {
+    V <- .vt_regimes(n)[[nm]]
+    expect_equal(.sdf(X, V), .sdf_ref(X, V), tolerance = 1e-8, info = nm)
+  }
+})
+
+test_that("Satterthwaite is invariant to the scale of the covariance", {
+  # it is a ratio of traces, so multiplying V by a constant must not change it
+  set.seed(12)
+  n <- 100L
+  X <- .vt_design(n, "er")
+  V <- .vt_ar1(n, 0.5)
+  expect_equal(.sdf(X, V), .sdf(X, 7.3 * V), tolerance = 1e-8)
+})
+
+test_that("stronger autocorrelation lowers the effective df, monotonically", {
+  set.seed(13)
+  n <- 150L
+  X <- .vt_design(n, "er")
+  rhos <- c(0, 0.2, 0.4, 0.6, 0.8, 0.9)
+  dfs <- vapply(rhos, function(r) .sdf(X, .vt_ar1(n, r)), numeric(1))
+
+  expect_equal(dfs[1], n - ncol(X), tolerance = 1e-8)   # rho = 0 is the iid case
+  expect_true(all(diff(dfs) < 0))                        # strictly decreasing
+  expect_true(all(dfs >= 1))
+  expect_true(all(dfs <= n - ncol(X) + 1e-8))            # never exceeds the iid df
+})
+
+test_that("Satterthwaite handles a rank-deficient design without erroring", {
+  set.seed(14)
+  n <- 80L
+  X <- cbind(1, rnorm(n), rnorm(n))
+  X <- cbind(X, X[, 2])                                  # exact duplicate column
+  expect_silent(d <- .sdf(X, diag(n)))
+  expect_gte(d, 1)
+})
+
+# -------------------------------------------------------------------- robust --
+
+test_that("robust weights scale the df by their mean", {
+  w <- c(rep(1, 90), rep(0, 10))
+  expect_equal(.edf(100, 5, robust_weights = w), 95 * 0.9, tolerance = 1e-10)
+  # all-ones weights must be a no-op
+  expect_equal(.edf(100, 5, robust_weights = rep(1, 100)), 95, tolerance = 1e-10)
+})
+
+test_that("robust and Satterthwaite adjustments compose multiplicatively", {
+  set.seed(15)
+  n <- 120L
+  X <- .vt_design(n, "er")
+  V <- .vt_ar1(n, 0.5)
+  w <- c(rep(1, 100), rep(0.5, 20))
+  base <- .edf(n, ncol(X), method = "satterthwaite", X = X, resid_cov = V)
+  both <- .edf(n, ncol(X), robust_weights = w, method = "satterthwaite",
+               X = X, resid_cov = V)
+  expect_equal(both, base * mean(w), tolerance = 1e-10)
+})
+
+# ------------------------------------------------- calibration (the real gate) --
+
+test_that("t statistics built on the reported df are calibrated under the null", {
+  # This is the property the old formula violated and no test checked: if the df
+  # is right, p-values from the null distribution are uniform and the rejection
+  # rate matches alpha.
+  skip_on_cran()
+  set.seed(2024)
+  n <- 160L
+  X <- .vt_design(n, "er")
+  p <- ncol(X)
+  cvec <- c(1, -1, rep(0, p - 2))
+  XtXinv <- solve(crossprod(X))
+  se_scale <- sqrt(drop(t(cvec) %*% XtXinv %*% cvec))
+  nrep <- 4000L
+  df <- .edf(n, p)
+
+  tvals <- numeric(nrep)
+  for (i in seq_len(nrep)) {
+    y <- rnorm(n)                                  # true contrast is 0
+    b <- drop(XtXinv %*% crossprod(X, y))
+    s2 <- sum((y - X %*% b)^2) / (n - p)
+    tvals[i] <- drop(cvec %*% b) / (sqrt(s2) * se_scale)
+  }
+  pvals <- 2 * pt(-abs(tvals), df)
+
+  # rejection rates track alpha; MC s.e. at alpha=.05 over 4000 reps is ~0.35pp
+  expect_lt(abs(mean(pvals < 0.05) - 0.05), 0.012)
+  expect_lt(abs(mean(pvals < 0.01) - 0.01), 0.006)
+  # and the p-values are uniform overall
+  expect_gt(suppressWarnings(ks.test(pvals, "punif")$p.value), 0.01)
+
+  # the old value would have been badly conservative here
+  df_old <- (n - p) / (1 + 2 * (1 - 1 / n))
+  p_old <- 2 * pt(-abs(tvals), df_old)
+  expect_lt(mean(p_old < 0.05), mean(pvals < 0.05))
+})
+
+test_that("Satterthwaite df calibrates OLS t statistics under correlated errors", {
+  # Unwhitened OLS with AR(1) errors: the naive n - p df is wrong, and the
+  # Satterthwaite df computed from the true covariance is much closer.
+  skip_on_cran()
+  set.seed(2025)
+  n <- 160L
+  X <- .vt_design(n, "er")
+  p <- ncol(X)
+  V <- .vt_ar1(n, 0.5)
+  Ch <- chol(V)
+  cvec <- c(1, -1, rep(0, p - 2))
+  XtXinv <- solve(crossprod(X))
+  Pm <- XtXinv %*% t(X)
+  # exact sampling variance of the contrast under OLS with covariance V
+  true_var <- drop(cvec %*% Pm %*% V %*% t(Pm) %*% cvec)
+  df_satt <- .sdf(X, V)
+
+  nrep <- 3000L
+  tvals <- numeric(nrep)
+  for (i in seq_len(nrep)) {
+    y <- drop(crossprod(Ch, rnorm(n)))
+    b <- drop(Pm %*% y)
+    tvals[i] <- drop(cvec %*% b) / sqrt(true_var)   # variance known; df is what is tested
+  }
+  # with the variance known and correct, the statistic is standard normal; the
+  # Satterthwaite df must be large enough that t_df is a good approximation
+  expect_gt(df_satt, 30)
+  expect_lt(df_satt, n - p)
+  expect_lt(abs(mean(abs(tvals) > qt(0.975, df_satt)) - 0.05), 0.015)
+})
+
+# ---------------------------------------------------------- end-to-end wiring --
+
+test_that("fmri_lm AR fits report residual df, not a deflated one", {
+  skip_if_not_installed("fmridataset")
+  set.seed(303)
+  TR <- 2; Tr <- 120L; n_run <- 1L; n_t <- Tr * n_run
+  onsets <- sort(runif(24, 0, Tr * TR - 20))
+  cond <- factor(rep(c("a", "b"), length.out = 24))
+  etab <- data.frame(onset = onsets, cond = cond, run = rep(1L, 24))
+  dset <- matrix_dataset(matrix(rnorm(n_t * 3), n_t, 3), TR = TR,
+                         run_length = Tr, event_table = etab)
+
+  fit_iid <- fmri_lm(onset ~ hrf(cond), block = ~ run, dataset = dset,
+                     ar_options = list(struct = "iid"))
+  fit_ar  <- fmri_lm(onset ~ hrf(cond), block = ~ run, dataset = dset,
+                     ar_options = list(struct = "ar1"))
+
+  se_iid <- as.matrix(standard_error(fit_iid, type = "estimates"))
+  se_ar  <- as.matrix(standard_error(fit_ar,  type = "estimates"))
+  expect_true(all(is.finite(se_iid)))
+  expect_true(all(is.finite(se_ar)))
+  expect_equal(dim(se_ar), dim(se_iid))
+
+  # The AR path used to report roughly a third of the residual df. Whichever df
+  # the contrast layer now uses, it must not be that deflated value: for this
+  # design the old formula gave about (n - p)/2.99.
+  df_resid <- .edf(n_t, ncol(as.matrix(design_matrix(fit_ar$model))))
+  df_old <- df_resid / (1 + 2 * (1 - 1 / n_t))
+  expect_gt(df_resid, 2 * df_old)
+})

--- a/tests/testthat/test-fmri-lm-argument-precedence.R
+++ b/tests/testthat/test-fmri-lm-argument-precedence.R
@@ -1,0 +1,167 @@
+# Precedence and conflict semantics for fmri_lm()'s configuration arguments.
+#
+# Nothing asserted this before, which is why three defects survived: robust_psi
+# was unreachable, an explicit robust = FALSE could be overridden, and cfg=
+# silently discarded every other configuration argument. Phase 1 of
+# docs/plans/fmri-lm-interface-redesign.md.
+
+.robust_norm <- function(...) fmrireg:::.fmri_lm_normalize_robust_options(...)
+.ar_norm     <- function(...) fmrireg:::.fmri_lm_normalize_ar_options(...)
+
+# ------------------------------------------------------------------ robust ----
+
+test_that("robust_psi is reachable and selects the psi function", {
+  # Regression: `robust` used to default to FALSE rather than NULL, so
+  # robust_options$type was always occupied before robust_psi was consulted and
+  # the argument had no observable effect anywhere.
+  expect_equal(.robust_norm(robust = NULL, robust_psi = "bisquare")$type, "bisquare")
+  expect_equal(.robust_norm(robust = NULL, robust_psi = "huber")$type, "huber")
+})
+
+test_that("unspecified robust settings default to no robust fitting", {
+  expect_false(.robust_norm(robust = NULL)$type)
+  expect_false(.robust_norm(robust = FALSE)$type)
+})
+
+test_that("an explicit robust = FALSE is not silently overridden", {
+  # Regression: robust = FALSE + robust_options = list(type = "huber") used to
+  # return "huber", i.e. explicitly disabling robust fitting enabled it.
+  expect_error(
+    .robust_norm(robust = FALSE, robust_options = list(type = "huber")),
+    "Conflicting robust settings"
+  )
+})
+
+test_that("robust settings that agree are accepted", {
+  expect_equal(.robust_norm(robust = "huber",
+                            robust_options = list(type = "huber"))$type, "huber")
+  # TRUE canonicalises to huber, so this agrees rather than conflicts
+  expect_equal(.robust_norm(robust = TRUE,
+                            robust_options = list(type = "huber"))$type, "huber")
+})
+
+test_that("non-type robust options coexist with a robust shorthand", {
+  # the shapes that actually occur in this repo's call sites
+  out <- .robust_norm(robust = "bisquare", robust_options = list(c_tukey = 4.685))
+  expect_equal(out$type, "bisquare")
+  expect_equal(out$c_tukey, 4.685)
+
+  out2 <- .robust_norm(robust = FALSE, robust_options = list(max_iter = 10L))
+  expect_false(out2$type)
+  expect_equal(out2$max_iter, 10L)
+})
+
+test_that("disagreeing robust spellings error whichever pair is used", {
+  expect_error(.robust_norm(robust = "huber", robust_psi = "bisquare"),
+               "Conflicting robust settings")
+  expect_error(.robust_norm(robust = NULL, robust_psi = "huber",
+                            robust_options = list(type = "bisquare")),
+               "Conflicting robust settings")
+})
+
+# ---------------------------------------------------------------------- AR ----
+
+test_that("AR shorthands apply when the options list does not set the key", {
+  expect_equal(.ar_norm(cor_struct = "ar2")$struct, "ar2")
+  expect_equal(.ar_norm(ar_options = list(struct = "arp"), ar_p = 4)$p, 4)
+  expect_true(.ar_norm(ar_options = list(struct = "ar1"), ar_voxelwise = TRUE)$voxelwise)
+})
+
+test_that("an AR shorthand that disagrees with ar_options is an error", {
+  # Regression: the list used to win silently. `ar_voxelwise` was additionally
+  # documented as overriding ar_options$voxelwise, which was backwards.
+  expect_error(.ar_norm(ar_options = list(struct = "ar2"), cor_struct = "ar1"),
+               "Conflicting AR settings")
+  expect_error(.ar_norm(ar_options = list(struct = "ar1", voxelwise = FALSE),
+                        ar_voxelwise = TRUE),
+               "Conflicting AR settings")
+  expect_error(.ar_norm(ar_options = list(struct = "arp", p = 2), ar_p = 4),
+               "Conflicting AR settings")
+})
+
+test_that("an AR shorthand that agrees with ar_options is accepted", {
+  expect_equal(.ar_norm(ar_options = list(struct = "ar2"), cor_struct = "ar2")$struct, "ar2")
+})
+
+test_that("voxelwise defaults to FALSE when nothing requests it", {
+  expect_false(.ar_norm(ar_options = list(struct = "ar1"))$voxelwise)
+  expect_false(.ar_norm()$voxelwise)
+})
+
+# --------------------------------------------------------------------- cfg ----
+
+test_that("cfg cannot be combined with other configuration arguments", {
+  # Regression: .fmri_lm_build_config computed the full normalisation and then
+  # discarded it when cfg was present, so cor_struct = "ar2" alongside a cfg
+  # naming "iid" silently ran iid.
+  cfg <- fmri_lm_control(ar_options = list(struct = "iid"))
+  expect_error(
+    fmrireg:::.fmri_lm_build_config(robust = NULL, cor_struct = "ar2", engine_cfg = cfg),
+    "cannot be combined"
+  )
+  expect_error(
+    fmrireg:::.fmri_lm_build_config(robust = TRUE, engine_cfg = cfg),
+    "cannot be combined"
+  )
+})
+
+test_that("cfg alone is passed through unchanged", {
+  cfg <- fmri_lm_control(ar_options = list(struct = "ar2"))
+  out <- fmrireg:::.fmri_lm_build_config(robust = NULL, engine_cfg = cfg)
+  expect_equal(out$ar$struct, "ar2")
+  expect_s3_class(out, "fmri_lm_config")
+})
+
+# ------------------------------------------------------------------ engine ----
+
+test_that("engine warns about the execution arguments it ignores", {
+  w <- fmrireg:::.fmri_lm_warn_engine_ignores
+  cl <- quote(fmri_lm(f, dataset = d, engine = "rrr_gls", strategy = "chunkwise",
+                      nchunks = 4))
+  expect_warning(w(cl, "rrr_gls"), "ignores")
+  expect_warning(w(cl, "rrr_gls"), "strategy")
+  expect_warning(w(cl, "rrr_gls"), "nchunks")
+
+  # nothing ignorable supplied -> silent
+  expect_silent(w(quote(fmri_lm(f, dataset = d, engine = "rrr_gls")), "rrr_gls"))
+})
+
+# ------------------------------------------------------- end-to-end on fits ----
+
+test_that("fmri_lm honours each configuration route and rejects conflicts", {
+  skip_if_not_installed("fmridataset")
+  set.seed(451)
+  TR <- 2; Tr <- 100L; n_run <- 2L; n_t <- Tr * n_run
+  onsets <- sort(runif(24, 0, Tr * TR - 20))
+  cond <- factor(rep(c("a", "b"), length.out = 24))
+  etab <- data.frame(onset = rep(onsets, n_run), cond = rep(cond, n_run),
+                     run = rep(seq_len(n_run), each = 24))
+  dset <- matrix_dataset(matrix(rnorm(n_t * 4), n_t, 4), TR = TR,
+                         run_length = rep(Tr, n_run), event_table = etab)
+  f <- onset ~ hrf(cond)
+
+  expect_s3_class(fmri_lm(f, block = ~ run, dataset = dset), "fmri_lm")
+  expect_s3_class(fmri_lm(f, block = ~ run, dataset = dset, cor_struct = "ar2"), "fmri_lm")
+  expect_s3_class(fmri_lm(f, block = ~ run, dataset = dset,
+                          ar_options = list(struct = "ar1")), "fmri_lm")
+  expect_s3_class(fmri_lm(f, block = ~ run, dataset = dset, robust = FALSE), "fmri_lm")
+  expect_s3_class(fmri_lm(f, block = ~ run, dataset = dset,
+                          cfg = fmri_lm_control(ar_options = list(struct = "iid"))),
+                  "fmri_lm")
+
+  expect_error(
+    fmri_lm(f, block = ~ run, dataset = dset, cor_struct = "ar2",
+            cfg = fmri_lm_control(ar_options = list(struct = "iid"))),
+    "cannot be combined"
+  )
+  expect_error(
+    fmri_lm(f, block = ~ run, dataset = dset, cor_struct = "ar1",
+            ar_options = list(struct = "ar2")),
+    "Conflicting AR settings"
+  )
+  expect_error(
+    fmri_lm(f, block = ~ run, dataset = dset, robust = FALSE,
+            robust_options = list(type = "huber")),
+    "Conflicting robust settings"
+  )
+})

--- a/tests/testthat/test-variance-closed-form.R
+++ b/tests/testthat/test-variance-closed-form.R
@@ -1,0 +1,249 @@
+# Closed-form validation of first-level variance.
+#
+# The package had extensive coverage of algebraic identities (F = t^2, F vs
+# anova(), engine-vs-engine parity) but nothing that checked a reported standard
+# error against an independently known covariance. These tests close that gap.
+#
+# Substrate (noise covariances, designs, the reduced-space oracle) lives in
+# helper-variance.R and deliberately does not call fmrireg.
+
+# ---------------------------------------------------------------- the oracle --
+# Validate the reference implementation before using it to judge anything else.
+
+test_that("reduced-space oracle reproduces L Sigma L' exactly", {
+  n_t <- 200
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  P <- solve(crossprod(X), t(X))
+  Cm <- rbind(c(1, 0, rep(0, p - 2)), c(1, -1, rep(0, p - 2)))
+  L <- Cm %*% P
+  run_id <- rep(1L, n_t)
+
+  for (nm in names(.vt_regimes(n_t))) {
+    Sigma <- .vt_regimes(n_t)[[nm]]
+    got <- .vt_reduced_var(L, list(`1` = Sigma[1, ]), run_id)
+    want <- L %*% Sigma %*% t(L)
+    expect_equal(got, want, tolerance = 1e-10,
+                 info = paste("covariance regime:", nm))
+  }
+})
+
+test_that("oracle with Sigma = I reproduces the classical OLS formula", {
+  n_t <- 160
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  Cm <- rbind(c(1, 0, rep(0, p - 2)), c(1, -1, rep(0, p - 2)))
+  L <- Cm %*% solve(crossprod(X), t(X))
+
+  got <- .vt_reduced_var(L, list(`1` = c(1, rep(0, 30))), rep(1L, n_t))
+  want <- Cm %*% solve(crossprod(X)) %*% t(Cm)
+  expect_equal(got, want, tolerance = 1e-12)
+})
+
+test_that("oracle handles multi-run, run-specific, heteroscedastic noise", {
+  n_run <- 3L; Tr <- 120L; n_t <- n_run * Tr
+  run_id <- rep(seq_len(n_run), each = Tr)
+
+  Xt <- do.call(rbind, lapply(seq_len(n_run),
+                              function(r) .vt_design(Tr, "er")[, 1:2, drop = FALSE]))
+  Nz <- matrix(0, n_t, 0)
+  for (r in seq_len(n_run)) {
+    D <- cbind(1, .vt_dct(Tr, 128))
+    B <- matrix(0, n_t, ncol(D)); B[run_id == r, ] <- D
+    Nz <- cbind(Nz, B)
+  }
+  X <- cbind(Xt, Nz); p <- ncol(X)
+  L <- rbind(c(1, 0, rep(0, p - 2)), c(1, -1, rep(0, p - 2))) %*% solve(crossprod(X), t(X))
+
+  # different noise structure AND different scale per run
+  gl <- list(`1` = .vt_ar1(Tr, 0.5)[1, ] * 1.0,
+             `2` = .vt_arma11(Tr, 0.6, 0.3)[1, ] * 1.4^2,
+             `3` = .vt_1f(Tr)[1, ] * 0.8^2)
+  Sigma <- matrix(0, n_t, n_t)
+  for (r in seq_len(n_run)) Sigma[run_id == r, run_id == r] <- stats::toeplitz(gl[[r]])
+
+  want <- L %*% Sigma %*% t(L)
+  expect_equal(.vt_reduced_var(L, gl, run_id), want, tolerance = 1e-10)
+
+  # Guard: ignoring run boundaries must be detected. Without this the test above
+  # would pass for an implementation that concatenates runs.
+  bad <- .vt_reduced_var(L, list(`1` = gl[[1]]), rep(1L, n_t))
+  expect_gt(max(abs(bad - want)) / max(abs(want)), 1e-3)
+})
+
+# ------------------------------------------------- fmrireg vs closed form -----
+
+test_that("beta_stats_matrix standard errors match summary(lm) exactly", {
+  set.seed(101)
+  n_t <- 180
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  y <- as.numeric(X %*% rnorm(p) + rnorm(n_t))
+
+  fit <- lm(y ~ X - 1)
+  se_lm <- unname(summary(fit)$coefficients[, "Std. Error"])
+
+  XtXinv <- solve(crossprod(X))
+  B <- matrix(coef(fit), ncol = 1)
+  sigma <- sqrt(sum(residuals(fit)^2) / (n_t - p))
+  res <- beta_stats_matrix(B, XtXinv, sigma, dfres = n_t - p,
+                           varnames = paste0("v", seq_len(p)))
+
+  expect_equal(as.numeric(res$data[[1]]$se[[1]]), se_lm, tolerance = 1e-10)
+})
+
+test_that(".fast_t_contrast standard error matches the closed form", {
+  set.seed(102)
+  n_t <- 180
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  y <- as.numeric(X %*% rnorm(p) + rnorm(n_t))
+  fit <- lm(y ~ X - 1)
+
+  XtXinv <- solve(crossprod(X))
+  B <- matrix(coef(fit), ncol = 1)
+  s2 <- sum(residuals(fit)^2) / (n_t - p)
+  cvec <- c(1, -1, rep(0, p - 2))
+
+  out <- .fast_t_contrast(B, sigma2 = s2, XtXinv = XtXinv,
+                          l = matrix(cvec, nrow = 1), df = n_t - p)
+
+  expect_equal(as.numeric(out$se), .vt_iid_se(X, s2, cvec), tolerance = 1e-10)
+  # and against an independent route through lm()
+  expect_equal(as.numeric(out$se),
+               unname(sqrt(t(cvec) %*% vcov(fit) %*% cvec)[1, 1]),
+               tolerance = 1e-10)
+})
+
+test_that("fmri_lm reports OLS standard errors that match lm()", {
+  skip_if_not_installed("fmridataset")
+  set.seed(103)
+  # single run: runwise fitting then coincides with one concatenated fit, so the
+  # comparison isolates the SE arithmetic from the run-pooling scheme
+  TR <- 2; Tr <- 120L; n_run <- 1L; n_t <- Tr * n_run
+
+  onsets <- sort(runif(30, 0, Tr * TR - 20))
+  cond <- factor(rep(c("a", "b"), length.out = 30))
+  etab <- data.frame(onset = rep(onsets, n_run),
+                     cond = rep(cond, n_run),
+                     run = rep(seq_len(n_run), each = 30))
+  Y <- matrix(rnorm(n_t * 3), n_t, 3)
+  dset <- matrix_dataset(Y, TR = TR, run_length = rep(Tr, n_run), event_table = etab)
+
+  fit <- fmri_lm(onset ~ hrf(cond), block = ~ run, dataset = dset,
+                 strategy = "runwise", ar_options = list(struct = "iid"))
+  se_pkg <- as.matrix(standard_error(fit, type = "estimates"))
+
+  # Independent route: recover the design fmrireg built and refit with lm()
+  X <- as.matrix(design_matrix(fit$model))
+  se_lm <- vapply(seq_len(ncol(Y)), function(v) {
+    unname(summary(lm(Y[, v] ~ X - 1))$coefficients[1, "Std. Error"])
+  }, numeric(1))
+
+  expect_equal(unname(se_pkg[, 1]), se_lm, tolerance = 1e-6)
+})
+
+# ------------------------------------------- external reference agreement -----
+
+test_that("calculate_sandwich_variance matches sandwich::vcovHC(HC0)", {
+  skip_if_not_installed("sandwich")
+  set.seed(104)
+  n_t <- 150
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  # heteroskedastic errors, so the sandwich genuinely differs from the OLS vcov
+  y <- as.numeric(X %*% rnorm(p) + rnorm(n_t) * seq(0.5, 2, length.out = n_t))
+  fit <- lm(y ~ X - 1)
+  r <- matrix(residuals(fit), ncol = 1)
+
+  # the function applies an n/(n-p) small-sample correction, i.e. HC1
+  got <- calculate_sandwich_variance(X, r, solve(crossprod(X)))
+  want <- sandwich::vcovHC(fit, type = "HC1")
+
+  expect_equal(unname(sqrt(diag(got))), unname(sqrt(diag(want))), tolerance = 1e-8)
+})
+
+test_that("compute_sandwich_variance matches sandwich::vcovHC", {
+  skip_if_not_installed("sandwich")
+  set.seed(105)
+  n_t <- 150
+  X <- .vt_design(n_t, "er")
+  p <- ncol(X)
+  y <- as.numeric(X %*% rnorm(p) + rnorm(n_t) * seq(0.5, 2, length.out = n_t))
+  fit <- lm(y ~ X - 1)
+  r <- matrix(residuals(fit), ncol = 1)
+
+  for (ty in c("HC0", "HC1")) {
+    got <- compute_sandwich_variance(X, r, type = ty)
+    want <- sandwich::vcovHC(fit, type = ty)
+    expect_equal(unname(sqrt(diag(got))), unname(sqrt(diag(want))),
+                 tolerance = 1e-8, info = ty)
+  }
+})
+
+test_that("bias correction recovers the true autocovariance from residuals", {
+  n_t <- 220
+  X <- .vt_design(n_t, "er")
+  H <- 25L
+  A <- .vt_bias_map(X, H)
+  M <- diag(n_t) - X %*% solve(crossprod(X), t(X))
+  d <- abs(outer(seq_len(n_t), seq_len(n_t), "-"))
+
+  # AR and ARMA covariances are supported within the lag budget; 1/f and the
+  # oscillatory regime are not, and are excluded by design (see below).
+  for (nm in c("AR(1) rho=0.4", "ARMA(1,1)")) {
+    Sigma <- .vt_regimes(n_t)[[nm]]
+    g_true <- Sigma[1, seq_len(H + 1L)]
+    g_raw <- .vt_lag_mean(M %*% Sigma %*% M, H, d)
+    g_corr <- solve(A, g_raw)
+
+    err_raw <- max(abs(g_raw / g_raw[1] - g_true / g_true[1]))
+    err_cor <- max(abs(g_corr / g_corr[1] - g_true / g_true[1]))
+
+    # the correction must work ...
+    expect_lt(err_cor, 1e-6)
+    # ... and the uncorrected estimator must be measurably biased, otherwise
+    # the assertion above is vacuous and would pass for a no-op correction.
+    expect_gt(err_raw, 0.02)
+  }
+})
+
+test_that("AR effective df is no longer phi-blind or deflated", {
+  # This began as a change detector pinning the old behaviour: calculate_effective_df()
+  # multiplied n - p by 1/(1 + 2*sum(1 - k/n)) whenever ar_order > 0, returning 62.9
+  # here regardless of the true autocorrelation, on top of whitening. Fixed
+  # 2026-08-07; the detector has done its job and now asserts the corrected
+  # contract. Full coverage lives in test-effective-df-correctness.R.
+  n <- 200; p <- 12
+
+  expect_equal(calculate_effective_df(n, p, ar_order = 1), n - p)
+  expect_equal(calculate_effective_df(n, p, ar_order = 2), n - p)
+
+  # the specific deflated value must not come back
+  expect_false(isTRUE(all.equal(calculate_effective_df(n, p, ar_order = 1),
+                                62.9, tolerance = 1e-2)))
+
+  # "satterthwaite" is a real method now, not an alias for the simple one
+  expect_error(calculate_effective_df(n, p, ar_order = 1, method = "satterthwaite"),
+               "requires both")
+})
+
+test_that("residual bias correction is limited by the lag budget", {
+  # Documents a real boundary of the method rather than asserting it away: when
+  # the true covariance has support beyond lag H, the truncated correction
+  # system cannot recover it. Consumers must either widen H or high-pass filter.
+  n_t <- 220
+  X <- .vt_design(n_t, "er")
+  H <- 25L
+  A <- .vt_bias_map(X, H)
+  M <- diag(n_t) - X %*% solve(crossprod(X), t(X))
+  d <- abs(outer(seq_len(n_t), seq_len(n_t), "-"))
+
+  Sigma <- .vt_regimes(n_t)[["AR+oscillatory"]]
+  g_true <- Sigma[1, seq_len(H + 1L)]
+  g_corr <- solve(A, .vt_lag_mean(M %*% Sigma %*% M, H, d))
+  err <- max(abs(g_corr / g_corr[1] - g_true / g_true[1]))
+
+  expect_gt(err, 1e-6)   # known limitation, asserted so a future fix is noticed
+  expect_lt(err, 0.2)    # but it must not be catastrophic
+})

--- a/tests/testthat/test-variance-noise-features.R
+++ b/tests/testthat/test-variance-noise-features.R
@@ -1,0 +1,147 @@
+# Integration between fmrireg's design-side variance machinery and fmriAR's
+# noise-covariance features (fmriAR >= 0.3.3: noise_acvf(), acvf_bias_matrix()).
+#
+# The split under test:
+#   fmriAR  owns Sigma  -- autocovariance, run segmentation, censoring, debiasing
+#   fmrireg owns L      -- the design/contrast projection and the combination
+# so Cov(C beta) = sum_h gamma_h (L T_h L').
+#
+# Oracle (helper-variance.R) calls neither package, so agreement between the two
+# is genuine cross-implementation evidence rather than a tautology.
+
+skip_if_no_acvf <- function() {
+  skip_if_not_installed("fmriAR")
+  if (!all(c("noise_acvf", "acvf_bias_matrix") %in% getNamespaceExports("fmriAR"))) {
+    skip("fmriAR >= 0.3.3 required for noise_acvf()/acvf_bias_matrix()")
+  }
+}
+
+test_that("fmriAR's residual-bias matrix matches the independent oracle", {
+  skip_if_no_acvf()
+  n_t <- 240L
+  H <- 20L
+  for (ty in c("er", "block")) {
+    X <- .vt_design(n_t, ty)
+    got <- fmriAR::acvf_bias_matrix(X, max_lag = H)[[1]]
+    want <- .vt_bias_map(X, H)
+    expect_equal(unname(got), unname(want), tolerance = 1e-8, info = ty)
+  }
+})
+
+test_that("lag budget is governed by the conditioning of the bias matrix", {
+  # cond(A) depends only on the design, so a safe max_lag can be chosen before
+  # any data is seen. It grows steeply, and past roughly 1e2 the debiasing solve
+  # amplifies noise faster than the extra lags buy accuracy.
+  skip_if_no_acvf()
+  n_t <- 300L
+  X <- .vt_design(n_t, "er")
+
+  kap <- vapply(c(15L, 25L, 40L, 60L), function(H) {
+    kappa(fmriAR::acvf_bias_matrix(X, max_lag = H)[[1]], exact = TRUE)
+  }, numeric(1))
+
+  expect_true(all(diff(kap) > 0))       # monotone in max_lag
+  expect_lt(kap[1], 50)                 # short budgets are well conditioned
+  expect_gt(kap[4], 1e3)                # long budgets are not
+})
+
+test_that("noise_acvf recovers autocovariance shape and scale after debiasing", {
+  skip_if_no_acvf()
+  set.seed(201)
+  n_t <- 300L
+  H <- 20L
+  V <- 2000L
+  X <- .vt_design(n_t, "er")
+  M <- diag(n_t) - X %*% solve(crossprod(X), t(X))
+  scale2 <- 2.5^2
+
+  for (nm in c("AR(1) rho=0.4", "ARMA(1,1)")) {
+    Sigma <- .vt_regimes(n_t)[[nm]] * scale2
+    E <- crossprod(chol(Sigma), matrix(rnorm(n_t * V), n_t, V))
+    R <- M %*% E
+    g_true <- Sigma[1, seq_len(H + 1L)]
+
+    raw <- fmriAR::noise_acvf(R, max_lag = H)
+    cor <- fmriAR::noise_acvf(R, max_lag = H, design = X, correction_max_lag = H)
+    expect_false(isTRUE(raw$corrected))
+    expect_true(isTRUE(cor$corrected))
+
+    g_raw <- as.numeric(raw$acvf[[1]])
+    g_cor <- as.numeric(cor$acvf[[1]])
+    err <- function(g) max(abs(g / g[1] - g_true / g_true[1]))
+
+    expect_lt(err(g_cor), 0.02)                       # shape recovered
+    expect_lt(abs(g_cor[1] / g_true[1] - 1), 0.02)    # and the scale, not just the shape
+    expect_lt(err(g_cor), err(g_raw))                 # correction is not a no-op
+    expect_gt(err(g_raw), 0.05)                       # ... and had something to fix
+  }
+})
+
+test_that("noise_acvf segments at run boundaries and censored frames", {
+  skip_if_no_acvf()
+  set.seed(202)
+  Tr <- 150L; n_run <- 2L; n_t <- Tr * n_run
+  runs <- rep(seq_len(n_run), each = Tr)
+  V <- 1500L
+
+  # white within run, large level shift between runs: a run-blind estimator
+  # reads the shift as long-range autocorrelation
+  E <- matrix(rnorm(n_t * V), n_t, V)
+  E[runs == 2, ] <- E[runs == 2, ] + 6
+
+  blind <- as.numeric(fmriAR::noise_acvf(E, max_lag = 6L)$acvf[[1]])
+  aware <- as.numeric(fmriAR::noise_acvf(E, runs = runs, max_lag = 6L)$acvf[[1]])
+
+  expect_gt(abs(blind[2] / blind[1]), 0.5)     # the bug this guards against
+  expect_lt(abs(aware[2] / aware[1]), 0.05)    # correct behaviour
+
+  # censored frames must not contribute
+  E2 <- matrix(rnorm(n_t * V), n_t, V)
+  bad <- c(40:45, 200:205)
+  E2[bad, ] <- E2[bad, ] + 50
+  keep <- as.numeric(fmriAR::noise_acvf(E2, runs = runs, max_lag = 6L)$acvf[[1]])
+  drop <- as.numeric(fmriAR::noise_acvf(E2, runs = runs, censor = bad,
+                                        max_lag = 6L)$acvf[[1]])
+  expect_gt(keep[1], 10)                       # corrupted frames dominate the variance
+  expect_lt(abs(drop[1] - 1), 0.1)             # ... and are excluded when censored
+})
+
+test_that("end-to-end: fmriAR features + reduced-space kernels give correct SEs", {
+  # The whole point of the split. Estimate gamma with fmriAR, project it through
+  # the design with the reduced-space identity, and check the resulting contrast
+  # standard error against the analytically known sqrt(L Sigma L').
+  skip_if_no_acvf()
+  set.seed(203)
+  n_t <- 300L
+  H <- 20L
+  V <- 400L
+  run_id <- rep(1L, n_t)
+
+  for (ty in c("er", "block")) {
+    X <- .vt_design(n_t, ty)
+    p <- ncol(X)
+    P <- solve(crossprod(X), t(X))
+    cvec <- c(1, -1, rep(0, p - 2))
+    L <- matrix(cvec, nrow = 1) %*% P
+
+    for (nm in c("AR(1) rho=0.4", "ARMA(1,1)")) {
+      Sigma <- .vt_regimes(n_t)[[nm]] * 1.7^2
+      Y <- crossprod(chol(Sigma), matrix(rnorm(n_t * V), n_t, V))
+      R <- Y - X %*% (P %*% Y)
+
+      g <- fmriAR::noise_acvf(R, max_lag = H, design = X,
+                              correction_max_lag = H)$acvf[[1]]
+      se_hat <- sqrt(drop(.vt_reduced_var(L, list(`1` = as.numeric(g)), run_id)))
+      se_true <- .vt_true_se(X, Sigma, cvec)
+
+      expect_lt(abs(se_hat / se_true - 1), 0.05,
+                label = sprintf("%s / %s: relative SE error", ty, nm))
+
+      # the naive iid standard error must be materially wrong here, otherwise
+      # the check above would pass for an estimator that ignores the noise model
+      s2_naive <- sum(R[, 1]^2) / (n_t - p)
+      se_naive <- .vt_iid_se(X, s2_naive, cvec)
+      expect_gt(abs(se_naive / se_true - 1), 0.05)
+    }
+  }
+})

--- a/tests/testthat/test_effective_df.R
+++ b/tests/testthat/test_effective_df.R
@@ -11,23 +11,34 @@ test_that("calculate_effective_df works correctly for basic cases", {
   df_eff <- fmrireg:::calculate_effective_df(n, p)
   expect_equal(df_eff, n - p)
   
-  # AR adjustment
+  # AR order alone does not reduce the df. fmrireg whitens before fitting, so the
+  # whitened residuals already carry n - p; deflating them again would
+  # double-count. Any genuine shortfall comes from the filter being imperfect and
+  # is measured by method = "satterthwaite" with the post-whitening covariance.
+  # (Before 2026-08-07 these returned ~31.8 and ~19.1 for every autocorrelation.)
   df_ar1 <- fmrireg:::calculate_effective_df(n, p, ar_order = 1)
-  expect_lt(df_ar1, n - p)  # Should be less due to AR correction
-  expect_gt(df_ar1, 0)      # Should still be positive
-  
+  expect_equal(df_ar1, n - p)
+
   df_ar2 <- fmrireg:::calculate_effective_df(n, p, ar_order = 2)
-  expect_lt(df_ar2, df_ar1)  # Higher AR order = more df loss
-  
+  expect_equal(df_ar2, n - p)
+
+  # Residual correlation that survives whitening does reduce it
+  X <- cbind(1, matrix(rnorm(n * (p - 1)), n, p - 1))
+  V <- 0.6^abs(outer(seq_len(n), seq_len(n), "-"))
+  df_satt <- fmrireg:::calculate_effective_df(n, p, method = "satterthwaite",
+                                              X = X, resid_cov = V)
+  expect_lt(df_satt, n - p)
+  expect_gt(df_satt, 0)
+
   # Robust adjustment
   weights <- rep(0.8, n)
   df_robust <- fmrireg:::calculate_effective_df(n, p, robust_weights = weights)
   expect_lt(df_robust, n - p)  # Downweighting reduces effective df
-  
-  # Combined adjustment
+
+  # Combined adjustment: robust scaling applies on top of the residual df
   df_combined <- fmrireg:::calculate_effective_df(n, p, ar_order = 1, robust_weights = weights)
+  expect_equal(df_combined, df_robust)
   expect_lt(df_combined, df_ar1)
-  expect_lt(df_combined, df_robust)
 })
 
 test_that("calculate_effective_df handles edge cases", {

--- a/tests/testthat/test_robust_args.R
+++ b/tests/testthat/test_robust_args.R
@@ -8,18 +8,32 @@ dset <- matrix_dataset(Y, TR=1, run_length=20, event_table=etab)
 # accept valid robust arguments
 test_that("fmri_lm accepts robust arguments", {
   # Robust fitting requires the fast engine (the runwise slow path rejects it).
-  expect_error(
-    fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
-            robust = TRUE, robust_psi = "huber", robust_max_iter = 2,
-            robust_scale_scope = "run", use_fast_path = TRUE),
-    NA
-  )
+  fit <- fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+                 robust = TRUE, robust_psi = "huber", robust_max_iter = 2,
+                 robust_scale_scope = "run", use_fast_path = TRUE)
+  cfg <- attr(fit, "executed_config")
+  expect_equal(cfg$robust$type, "huber")
+  expect_equal(cfg$robust$max_iter, 2)
+  expect_equal(cfg$robust$scale_scope, "run")
 
+  # robust_psi selects the psi function on its own. This previously had no
+  # effect at all -- `robust` defaulted to FALSE and always claimed `type`
+  # first -- so the argument was silently dead.
+  fit2 <- fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
+                  robust_psi = "bisquare", robust_max_iter = 1,
+                  robust_scale_scope = "global", use_fast_path = TRUE)
+  cfg2 <- attr(fit2, "executed_config")
+  expect_equal(cfg2$robust$type, "bisquare")
+  expect_equal(cfg2$robust$scale_scope, "global")
+})
+
+test_that("robust = TRUE and robust_psi = 'bisquare' is a conflict, not a silent win", {
+  # This combination used to be accepted and quietly fit Huber. It is a genuine
+  # contradiction: TRUE canonicalises to huber.
   expect_error(
     fmri_lm(onset ~ hrf(repnum), block = ~ run, dataset = dset,
-            robust = TRUE, robust_psi = "bisquare", robust_max_iter = 1,
-            robust_scale_scope = "global", use_fast_path = TRUE),
-    NA
+            robust = TRUE, robust_psi = "bisquare", use_fast_path = TRUE),
+    "Conflicting robust settings"
   )
 })
 


### PR DESCRIPTION
Six defects in first-level inference and `fmri_lm()`'s argument handling, each
verified by execution rather than reading, plus the closed-form variance tests
that should have caught them.

**Suite: 2679 pass, 0 fail, 0 error.**

## Changes reported AR p-values — read this first

`calculate_effective_df()` applied `1 / (1 + 2 * sum(1 - k/n))` whenever
`ar_order > 0`. That factor is the variance inflation one would obtain if *every*
autocorrelation equalled 1. It never depended on the fitted AR coefficients — at
`n = 200`, `p = 12`, AR(1) it returned **62.9 whether the true autocorrelation was
0.05 or 0.9**, where a coefficient-aware calculation spans roughly 170 to 10 — and
it was applied *on top of* prewhitening.

Since fmrireg whitens and then fits by OLS, adequate whitening already leaves
`n - p` degrees of freedom; deflating again double-counts a correction already
made. AR order by itself no longer reduces the df. What legitimately costs
degrees of freedom is residual correlation *surviving* the filter, and
`method = "satterthwaite"` now measures exactly that — `tr(RV)^2 / tr(RVRV)`,
reducing exactly to `n - p` when `V = I`. It was previously a verbatim duplicate
of `method = "simple"`.

**Impact:** AR p-values become less conservative; df roughly triples for AR(1).
The old behaviour cost statistical power rather than inflating false positives,
so results significant under the old code stay significant — but p-values and
anything power-sensitive will differ from earlier versions.

## Silent resolution replaced by errors

| defect | before | after |
|---|---|---|
| `robust_psi` | structurally unreachable (`robust` defaulted to `FALSE`, not `NULL`, so `robust_options$type` was always claimed first) | works; `robust` defaults to `NULL` so "unspecified" is distinguishable from "explicitly off" |
| explicit `robust = FALSE` | silently overridden to `"huber"` by `robust_options` | error |
| `cfg =` | discarded every other configuration argument (`cor_struct = "ar2"` + a cfg naming `"iid"` ran IID) | error naming the offenders |
| AR shorthands | silently dropped when they disagreed with `ar_options` | error on disagreement, accepted when they agree |
| `engine =` | silently ignored six execution formals | warns, naming them |

I confirmed by AST scan before changing precedence that **no call site anywhere
passes a conflicting pair**, so the new errors cannot fire on existing code.

## Other fixes

- `compute_sandwich_variance()` computed its meat as `X' diag(e^4) X` rather than
  `X' diag(e^2) X`, giving standard errors ~3.5x too large. Both sandwich helpers
  are now checked against `sandwich::vcovHC()`.
- Hoisted a per-voxel `.fast_preproject()` call on a voxel-invariant design out of
  both voxelwise loops — it performs an `n x n` solve and was recomputed for every
  voxel. **4.95s → 2.98s** for 2000 voxels at 300 timepoints (1.7x).
- Docs that contradicted behaviour: `ar_voxelwise` was documented as overriding
  `ar_options$voxelwise` (it never did), `use_fast_path` as defaulting to `FALSE`
  (it is `TRUE`), and three places claimed sandwich variance is applied
  automatically (no fitting path calls it; the robust path reports a model-based
  WLS variance). Its degrees-of-freedom formula was also wrong.
- `fmriAR` gains a minimum version (`>= 0.3.3`) and a `Remotes:` entry; it had
  neither, so an older install would have failed with a confusing `NULL`.

## Tests

The package had good coverage of algebraic identities and engine-vs-engine
parity, and **nothing that compared a reported standard error against a known
covariance**. That gap is why these survived.

New: a reduced-space variance oracle that calls neither fmrireg nor fmriAR;
agreement with `lm()`, `nlme::gls`, and `sandwich::vcovHC`; fmriAR noise-feature
integration (`acvf_bias_matrix()` matches the independent oracle to 1.79e-14);
and Monte Carlo calibration gates for the degrees of freedom — null p-values
uniform by KS with rejection rates within 1.2pp of alpha=.05 and 0.6pp of
alpha=.01 over 4000 reps.

Every gate was checked to actually discriminate by injecting the corresponding
bug and confirming it fires.

Three existing tests asserted the deflation (`test_effective_df.R:16,20,30`) and
were rewritten to the correct contract. One asserted that a self-contradictory
call succeeds (`robust = TRUE` with `robust_psi = "bisquare"`) via
`expect_error(..., NA)`, which could never have failed either way; it now asserts
the executed config.

## Review notes

The degrees-of-freedom change is the one item that alters numbers users have
already reported, and it is called out under its own heading in NEWS. Worth a
second opinion on whether `n - p` is the contract you want for the AR path, or
whether you would rather wire the Satterthwaite path in by default once the
post-whitening covariance is plumbed to the contrast layer.

Related: bbuchsbaum/fmriAR#2 (closed), bbuchsbaum/fmriAR#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)