### PR TITLE
Stop teaching a robust argument combination that is now an error

### DIFF
--- a/vignettes/a_09_linear_model.Rmd
+++ b/vignettes/a_09_linear_model.Rmd
@@ -289,9 +289,15 @@ models. This setting models AR coefficients only (no moving-average terms).
 ### Handling Outliers with Row-Wise Robust Fitting
 
 Real fMRI runs sometimes contain entire time points corrupted by motion or scanner artifacts. The `fmri_lm`
-function can mitigate their impact by enabling row-wise robust weighting. When `robust = TRUE`, an
-Iteratively Reweighted Least Squares loop down-weights frames with large residuals. The `robust_psi`
-argument selects the weighting function and `robust_max_iter` controls the number of iterations.
+function can mitigate their impact by enabling row-wise robust weighting: an Iteratively Reweighted Least
+Squares loop down-weights frames with large residuals. Name the weighting function directly with
+`robust = "huber"` or `robust = "bisquare"`, and control the number of iterations with `robust_max_iter`.
+`robust = TRUE` is shorthand for `"huber"`.
+
+Each option has one spelling per call. `robust`, `robust_psi`, and `robust_options$type` all set the same
+field, so supplying two of them with *different* values is an error rather than a silent choice —
+`robust = TRUE` together with `robust_psi = "bisquare"` is a contradiction, since `TRUE` already means
+Huber. The same rule applies to the AR shorthands and their `ar_options` entries.
 
 ```{r fit-robust-model, message=FALSE}
 model_robust <- fmri_lm(
@@ -300,8 +306,7 @@ model_robust <- fmri_lm(
   dataset = dataset,
   strategy = "chunkwise",
   nchunks = 1,
-  robust = TRUE,
-  robust_psi = "huber",
+  robust = "huber",
   robust_max_iter = 2
 )
 


### PR DESCRIPTION
Follow-up to #204, which merged while I was checking the vignettes.

## What

`vignettes/a_09_linear_model.Rmd` taught this pattern:

```r
fmri_lm(..., robust = TRUE, robust_psi = "huber", robust_max_iter = 2)
```

That still works, but only because the two agree — `TRUE` canonicalises to
Huber. A reader following the pattern and switching to
`robust_psi = "bisquare"` while leaving `robust = TRUE` now gets a conflict
error, because those are contradictory requests for the same field.

The example now uses `robust = "huber"` directly, and the surrounding prose
states the rule: each option has one spelling per call, and supplying two
spellings with different values is an error rather than a silent choice. The
same applies to the AR shorthands and their `ar_options` entries.

## Vignette check

All 11 vignettes build against the merged #204 changes.

Two things worth recording from the check, since both cost me time:

- `rmarkdown::render()` defaults to `envir = parent.frame()`, so vignette code
  can overwrite the caller's variables. Batch-building in a loop without
  `envir = new.env()` produces confusing phantom failures — I chased one in
  `group_analysis.Rmd` that turned out to be variable contamination from a
  previously-rendered vignette, not a real error.
- No vignette prose described the old AR degrees-of-freedom behaviour, so
  nothing was left factually stale by #204. Statements like "all conditions
  show significant activity" remain true, since the correction makes p-values
  smaller rather than larger.

An AST scan of every vignette's code found no other call combining a shorthand
with a conflicting options-list entry. `plugin-development.Rmd` passes
`robust = FALSE` alongside `robust_options = list(max_iter = 10L)`, but that
sets no `type`, so it is not a conflict and builds fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)